### PR TITLE
Use plugin ID instead of class name for dependency-management-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ sensible defaults. By applying them, you can:
            mavenCentral()
        }
        dependencies {
-           classpath "com.google.gradle:osdetector-gradle-plugin:1.4.0"
+           classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
+           classpath 'io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE'
        }
    }
 

--- a/build-flags.gradle
+++ b/build-flags.gradle
@@ -1,5 +1,6 @@
 def libDir = new File(buildscript.sourceFile.parentFile, 'lib')
 
+apply from: "${libDir}/prerequisite.gradle"
 apply from: "${libDir}/common-dependencies.gradle"
 apply from: "${libDir}/common-git.gradle"
 apply from: "${libDir}/common-info.gradle"

--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -64,7 +64,7 @@ rootProject.ext {
 }
 
 allprojects {
-    apply plugin: io.spring.gradle.dependencymanagement.DependencyManagementPlugin
+    apply plugin: 'io.spring.dependency-management'
 
     dependencyManagement {
         generatedPomCustomization {

--- a/lib/common-info.gradle
+++ b/lib/common-info.gradle
@@ -13,27 +13,6 @@ rootProject.ext {
     scmUrl = project.findProperty('scmUrl')
     scmConnection = project.findProperty('scmConnection')
     scmDeveloperConnection = project.findProperty('scmDeveloperConnection')
-
-    if (projectName == null || projectUrl == null ||
-        inceptionYear == null || licenseName == null || licenseUrl == null ||
-        scmUrl == null || scmConnection == null || scmDeveloperConnection == null) {
-        throw new IllegalStateException('''Add project info properties to gradle.properties:
-
-projectName=My Example
-projectUrl=https://www.example.com/
-projectDescription=My example project
-authorName=John Doe
-authorEmail=john@doe.com
-authorUrl=https://john.doe.com/
-inceptionYear=2018
-licenseName=The Apache License, Version 2.0
-licenseUrl=https://www.apache.org/license/LICENSE-2.0.txt
-scmUrl=https://github.com/john.doe/example
-scmConnection=scm:git:https://github.com/john.doe/example.git
-scmDeveloperConnection=scm:git:ssh://git@github.com/john.doe/example.git
-''')
-    }
-
     copyrightFooter =
             '&copy; Copyright ' + "${rootProject.ext.inceptionYear}&ndash;${LocalDateTime.now().year} " +
             '<a href="' + rootProject.ext.authorUrl + '">' + rootProject.ext.authorName + '</a>. ' +

--- a/lib/common-publish.gradle
+++ b/lib/common-publish.gradle
@@ -5,17 +5,6 @@ def publishUrlForSnapshot = rootProject.findProperty('publishUrlForSnapshot')
 def publishUsernameProperty = rootProject.findProperty('publishUsernameProperty')
 def publishPasswordProperty = rootProject.findProperty('publishPasswordProperty')
 
-if (publishUrlForRelease == null || publishUrlForSnapshot == null ||
-    publishUsernameProperty == null || publishPasswordProperty == null) {
-    throw new IllegalStateException('''Add publication properties to gradle.properties:
-
-publishUrlForRelease=https://oss.sonatype.org/service/local/staging/deploy/maven2/
-publishUrlForSnapshot=https://oss.sonatype.org/content/repositories/snapshots/
-publishUsernameProperty=ossrhUsername
-publishPasswordProperty=ossrhPassword
-''')
-}
-
 if (publishSignatureRequired) {
     apply plugin: 'signing'
 }

--- a/lib/java-rpc-proto.gradle
+++ b/lib/java-rpc-proto.gradle
@@ -10,7 +10,7 @@ buildscript {
 configure(projectsWithFlags('java')) {
     // Add protobuf/gRPC support if there is src/*/proto
     if (project.ext.hasSourceDirectory('proto')) {
-        project.ext.applyOsDetectorPlugin()
+        apply plugin: 'com.google.osdetector'
         apply plugin: com.google.protobuf.gradle.ProtobufPlugin
 
         protobuf {

--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -3,7 +3,7 @@ def libDir = "${buildscript.sourceFile.parentFile}"
 configure(projectsWithFlags('java')) {
     // Add Thrift support if there is src/*/thrift
     if (project.ext.hasSourceDirectory('thrift')) {
-        project.ext.applyOsDetectorPlugin()
+        apply plugin: 'com.google.osdetector'
         def thriftJsonEnabled = true
         ext {
             thriftVersion = '0.10'

--- a/lib/java-rpc.gradle
+++ b/lib/java-rpc.gradle
@@ -1,6 +1,5 @@
 allprojects {
     ext {
-        applyOsDetectorPlugin = this.&applyOsDetectorPlugin.curry(project)
         hasSourceDirectory = this.&hasSourceDirectory.curry(project)
     }
 }
@@ -13,29 +12,6 @@ configure(projectsWithFlags('java')) {
     // Delete the generated source directory on clean.
     clean {
         delete project.ext.genSrcDir
-    }
-}
-
-static void applyOsDetectorPlugin(Project project) {
-    // Ensure osdetector-gradle-plugin is available, because:
-    // - protobuf-gradle-plugin calls project.apply([plugin: 'com.google.osdetector'])
-    // - applying a plugin with ID from an external script is not supported yet.
-    // See: https://github.com/gradle/gradle/issues/1262
-
-    try {
-        project.apply plugin: 'com.google.osdetector'
-    } catch (UnknownPluginException e) {
-        throw new IllegalStateException('''Add the following to the top-level build.gradle file:
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
-    }
-}
-''', e)
     }
 }
 

--- a/lib/prerequisite.gradle
+++ b/lib/prerequisite.gradle
@@ -1,0 +1,44 @@
+try {
+    rootProject.apply plugin: 'com.google.osdetector'
+    rootProject.apply plugin: 'io.spring.dependency-management'
+} catch (UnknownPluginException e) {
+    throw new IllegalStateException('''Add the following to the top-level build.gradle file:
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
+        classpath 'io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE'
+    }
+}
+''')
+}
+
+['projectName', 'projectUrl', 'inceptionYear', 'licenseName', 'licenseUrl', 'scmUrl', 'scmConnection',
+ 'scmDeveloperConnection', 'publishUrlForRelease', 'publishUrlForSnapshot', 'publishUsernameProperty',
+ 'publishPasswordProperty'].each {
+    if (rootProject.findProperty(it) == null) {
+        throw new IllegalStateException('''Add project info properties to gradle.properties:
+
+projectName=My Example
+projectUrl=https://www.example.com/
+projectDescription=My example project
+authorName=John Doe
+authorEmail=john@doe.com
+authorUrl=https://john.doe.com/
+inceptionYear=2018
+licenseName=The Apache License, Version 2.0
+licenseUrl=https://www.apache.org/license/LICENSE-2.0.txt
+scmUrl=https://github.com/john.doe/example
+scmConnection=scm:git:https://github.com/john.doe/example.git
+scmDeveloperConnection=scm:git:ssh://git@github.com/john.doe/example.git
+publishUrlForRelease=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+publishUrlForSnapshot=https://oss.sonatype.org/content/repositories/snapshots/
+publishUsernameProperty=ossrhUsername
+publishPasswordProperty=ossrhPassword
+versionPattern=^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$
+''')
+    }
+}


### PR DESCRIPTION
Motivation:

Some third party plugins attempt to apply the
dependency-management-plugin using its plugin ID, which conflicts with
common-dependencies.gradle which uses class name.

Modifications:

- Ask a user to add dependency-management-plugin to classpath so that
  common-dependencies.gradle can apply it using the plugin ID
- Add prerequisite.gradle which is responsible for displaying example
  configuration when required plugins or properties are not set up

Result:

- Our scripts work with other plugins that attempt to apply
  dependency-management-plugin, such as spring-boot-gradle-plugin.