### PR TITLE
Generate IDEA/Eclipse project files for root project

### DIFF
--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -6,6 +6,11 @@ def checkstyleEnabled = new File(checkstyleConfigDir).isDirectory() &&
 // Enable JaCoCo test coverage when '-Pcoverage' option is specified.
 def jacocoEnabled = project.hasProperty('coverage')
 
+configure(rootProject) {
+    apply plugin: 'eclipse'
+    apply plugin: 'idea'
+}
+
 configure(projectsWithFlags('java')) {
 
     apply plugin: 'java'


### PR DESCRIPTION
We should apply 'idea' and 'eclipse' plugin to the root project so that
the IDE plugins generate the project file at the project root directory.