### PR TITLE
Fix 'version' property validation for gradle.properties

### DIFF
--- a/lib/common-release.gradle
+++ b/lib/common-release.gradle
@@ -72,8 +72,11 @@ task release(
 
         def gradlePropsFile = project.file("${project.projectDir}/gradle.properties")
         def gradlePropsContent = gradlePropsFile.getText('ISO-8859-1')
-        def versionPattern = /\nversion=[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT(\r?\n)/
-        assert gradlePropsContent =~ versionPattern
+        def versionPattern = /\nversion=[^\r\n]*(\r?\n)/
+        if (!(gradlePropsContent =~ versionPattern)) {
+            throw new IllegalStateException(
+                    "Cannot find a valid 'version' property from gradle.properties");
+        }
 
         // Update the version to the release version, commit and tag.
         gradlePropsFile.write(gradlePropsContent.replaceFirst(versionPattern, "\nversion=${releaseVersion}\$1"),


### PR DESCRIPTION
Motivation:

The validation of the `version' property in `gradle.properties` is
overly strict and it always fails when a project uses non-default
version pattern.

Modifications:

- Relax the version validation
- Throw an exception instead of failing an assertion for a more
  user-friendly error message

Result:

A user can release when a project uses non-default version pattern.