### PR TITLE
Make 'version' property optional in dependencies.yml

### DIFF
--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -23,44 +23,6 @@ rootProject.ext {
     } else {
         dependenciesYaml = Collections.emptyMap()
     }
-
-    // Build the relocation table from dependencies.yml.
-    relocations = dependenciesYaml.entrySet().inject([]) { list, Map.Entry<String, Object> entry ->
-        if (entry.key != 'boms') {
-            def groupId = entry.key
-            entry.value.forEach { String artifactId, Map props ->
-                if (props.containsKey('relocations')) {
-                    props.get('relocations').each {
-                        list.add([
-                                name: "${groupId}:${artifactId}",
-                                from: it['from'],
-                                to: it['to']])
-                    }
-                }
-            }
-        }
-        return list
-    }
-
-    javadocLinks = dependenciesYaml.entrySet().inject([]) { list, Map.Entry<String, Object> entry ->
-        if (entry.key != 'boms') {
-            def groupId = entry.key
-            entry.value.forEach { String artifactId, Map props ->
-                def version = "${props['version']}"
-                if (props.containsKey('javadocs')) {
-                    props['javadocs'].each { url ->
-                        list.add([
-                                groupId: groupId,
-                                artifactId: artifactId,
-                                version: version,
-                                url: url
-                        ])
-                    }
-                }
-            }
-        }
-        return list
-    }
 }
 
 allprojects {
@@ -85,10 +47,12 @@ allprojects {
                     def groupId = key
                     def artifact = value as Map
                     artifact.forEach { String artifactId, Map props ->
-                        dependency("${groupId}:${artifactId}:${props['version']}") {
-                            if (props.containsKey('exclusions')) {
-                                props['exclusions'].each { String spec ->
-                                    exclude spec
+                        if (props.containsKey('version')) {
+                            dependency("${groupId}:${artifactId}:${props['version']}") {
+                                if (props.containsKey('exclusions')) {
+                                    props['exclusions'].each { String spec ->
+                                        exclude spec
+                                    }
                                 }
                             }
                         }
@@ -100,6 +64,46 @@ allprojects {
 
     ext {
         managedVersions = dependencyManagement.managedVersions
+    }
+}
+
+rootProject.ext {
+    // Build the relocation table from dependencies.yml.
+    relocations = dependenciesYaml.entrySet().inject([]) { list, Map.Entry<String, Object> entry ->
+        if (entry.key != 'boms') {
+            def groupId = entry.key
+            entry.value.forEach { String artifactId, Map props ->
+                if (props.containsKey('relocations')) {
+                    props.get('relocations').each {
+                        list.add([
+                                name: "${groupId}:${artifactId}",
+                                from: it['from'],
+                                to: it['to']])
+                    }
+                }
+            }
+        }
+        return list
+    }
+
+    javadocLinks = dependenciesYaml.entrySet().inject([]) { list, Map.Entry<String, Object> entry ->
+        if (entry.key != 'boms') {
+            def groupId = entry.key
+            entry.value.forEach { String artifactId, Map props ->
+                if (props.containsKey('javadocs')) {
+                    def version = String.valueOf(managedVersions["${groupId}:${artifactId}"])
+                    props['javadocs'].each { url ->
+                        list.add([
+                                groupId: groupId,
+                                artifactId: artifactId,
+                                version: version,
+                                url: url
+                        ])
+                    }
+                }
+            }
+        }
+        return list
     }
 }
 


### PR DESCRIPTION
Motivation:

When a user imports a BOM in a dependencies.yml, there should be no need
to specify the version property of the dependency when he or she
specifies the Javadoc links or relocations. For example:

    boms:
    - com.linecorp.armeria:armeria-bom:0.58.0

    # Use the Guava version in armeria-bom.
    com.google.common:
      guava:
        relocations:
        - from: ...
          to: ...

Modifications:

- Make 'version' property optional in dependencies.yml

Result:

No need to specify version numbers when BOM defines them