### PR TITLE
Add 'managedVersions' task that generates managed_versions.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ applied so you can conveniently check if your dependencies are out of date:
 $ ./gradlew dependencyUpdates -Drevision=release
 ...
 The following dependencies have later integration versions:
- - com.google.guava:guava [0.17 -> 23.6-jre]
+ - com.google.guava:guava [17.0 -> 24.0-jre]
 ```
 
 ## Built-in properties and functions

--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -114,3 +114,16 @@ subprojects {
         javadocLinks = rootProject.ext.javadocLinks
     }
 }
+
+configure(rootProject) {
+    task managedVersions(
+            group: 'Build',
+            description: 'Generates the file that contains dependency versions.') {
+        inputs.properties dependencyManagement.managedVersions
+        doLast {
+            file("${project.buildDir}/managed_versions.yml").withWriter('UTF-8') {
+                new Yaml().dump(dependencyManagement.managedVersions, it)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

It is sometimes required to export the complete dependency lists and
their version numbers to a file so that an external command can consume
it, e.g. Sphinx

Modifications:

- Add a task 'managedVersions' to the root project

Result:

An external command such as Sphinx can consume the dependency
information.