### PR TITLE
Include project's own artifacts in BOM

### DIFF
--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -16,18 +16,7 @@ configure(projectsWithFlags('bom')) {
                 pom.packaging = 'pom'
                 // Generate the POM.
                 pom.withXml {
-                    Node packaging = asNode().children().find {
-                        def name = it.name()
-                        if (name instanceof QName) {
-                            name = name.localPart
-                        } else {
-                            name = name.toString()
-                        }
-
-                        return name == 'packaging'
-                    }
-
-                    packaging + {
+                    findChildNode(asNode(), 'packaging') + {
                         resolveStrategy = DELEGATE_FIRST
 
                         // Write the elements required by OSSRH.
@@ -57,6 +46,90 @@ configure(projectsWithFlags('bom')) {
                             connection "${project.ext.scmConnection}"
                             developerConnection "${project.ext.scmDeveloperConnection}"
                         }
+                    }
+
+                    // Find (or create) the 'dependencyManagement' section.
+                    Node dependencyMgmt = findChildNode(asNode(), 'dependencyManagement')
+                    if (dependencyMgmt == null) {
+                        findChildNode(asNode(), 'scm') + {
+                            resolveStrategy = DELEGATE_FIRST
+                            dependencyManagement {
+                                dependencies {
+                                    deleteMe {} // Placeholder to use the Node.plus(Closure)
+                                }
+                            }
+                        }
+                        dependencyMgmt = findChildNode(asNode(), 'dependencyManagement')
+                    }
+
+                    // Add our own projects to the 'dependencies' sections.
+                    List<Node> dependencies = findChildNode(dependencyMgmt, 'dependencies').children()
+                    dependencies.last() + {
+                        resolveStrategy = DELEGATE_FIRST
+                        projectsWithFlags('java', 'publish').each { Project p ->
+                            dependency {
+                                groupId "${p.group}"
+                                artifactId "${p.ext.artifactId}"
+                                version "${p.version}"
+                            }
+                            if (p.hasFlags('relocate')) {
+                                dependency {
+                                    groupId "${p.group}"
+                                    artifactId "${p.ext.artifactId}-shaded"
+                                    version "${p.version}"
+                                }
+                            }
+                        }
+                    }
+
+                    // Remove the 'deleteMe' placeholder we added above.
+                    dependencies.removeIf {
+                        def name = it.name()
+                        if (name instanceof QName) {
+                            name = name.localPart
+                        } else {
+                            name = name.toString()
+                        }
+
+                        return name == 'deleteMe'
+                    }
+
+                    // Sort the dependencies for aesthetics.
+                    dependencies.sort { a, b ->
+                        // BOM import comes first.
+                        def scopeNodeA = findChildNode(a, 'scope')
+                        def scopeNodeB = findChildNode(b, 'scope')
+                        def scopeA = scopeNodeA != null ? scopeNodeA.text() : ''
+                        def scopeB = scopeNodeB != null ? scopeNodeB.text() : ''
+                        if (scopeA == 'import') {
+                            if (scopeB != 'import') {
+                                return -1
+                            }
+                        } else if (scopeB == 'import') {
+                            return 1
+                        }
+
+                        // Our own group comes first.
+                        def groupA = findChildNode(a, 'groupId').text()
+                        def groupB = findChildNode(b, 'groupId').text()
+                        if (groupA == rootProject.group) {
+                            if (groupB != rootProject.group) {
+                                return -1
+                            }
+                        } else if (groupB == rootProject.group) {
+                            return 1
+                        }
+
+                        // Sort by groupId alphabetically otherwise.
+                        def groupComparison = groupA.compareTo(groupB)
+                        if (groupComparison != 0) {
+                            return groupComparison
+                        }
+
+                        // Sort by artifactId.
+                        def artifactA = findChildNode(a, 'artifactId').text()
+                        def artifactB = findChildNode(b, 'artifactId').text()
+                        return artifactA.compareTo(artifactB);
                     }
                 }
 
@@ -102,4 +175,17 @@ configure(projectsWithFlags('bom')) {
     tasks.assemble.dependsOn {
         tasks.generatePomFileForBomPublication
     }
+}
+
+private static Node findChildNode(Node parent, String childName) {
+    return parent.children().find {
+        def name = it.name()
+        if (name instanceof QName) {
+            name = name.localPart
+        } else {
+            name = name.toString()
+        }
+
+        return name == childName
+    } as Node
 }


### PR DESCRIPTION
Motivation:

The BOM file generated by 'lib/bom.gradle' should contain all artifacts
produced by the project.

Modification:

- Add all project artifacts
- Sort the dependencyManagements section

Result:

- Generated BOMs do not omit essential artifacts.
- Fixes https://github.com/line/armeria/issues/1008