### PR TITLE
Add 'offlineJavadoc' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ When a project has a `java` flag:
       - https://developers.google.com/protocol-buffers/docs/reference/java/
   ```
 
+  If you are in an environment with restricted network access, you can specify
+  `-PofflineJavadoc` option to disable the downloads.
+
 - The `.proto` files under `src/*/proto` will be compiled into Java code with
   [protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin).
 

--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -1,5 +1,6 @@
 import java.security.MessageDigest
 
+def offlineJavadoc = rootProject.hasProperty('offlineJavadoc')
 def javadocCacheDir = new File(gradle.gradleUserHomeDir, 'caches/package-lists')
 def defaultStylesheetFile = new File(buildscript.sourceFile.parentFile, 'java-javadoc.css')
 
@@ -121,7 +122,7 @@ allprojects {
 
                 def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
                 def packageListFile = new File(javadocCacheDir, "${name}/${javadocUrlSha1}/package-list")
-                if (!packageListFile.exists()) {
+                if (!packageListFile.exists() && !offlineJavadoc) {
                     packageListFile.parentFile.mkdirs()
                     def packageListUrl = new URL("${javadocUrl}package-list")
                     logger.lifecycle("Downloading: ${packageListUrl}")
@@ -141,7 +142,9 @@ allprojects {
                     }
                 }
 
-                linksOffline javadocUrl, "${packageListFile.parentFile}"
+                if (packageListFile.exists()) {
+                    linksOffline javadocUrl, "${packageListFile.parentFile}"
+                }
             }
 
             addOfflineLink('java9', 'https://docs.oracle.com/javase/9/docs/api/')


### PR DESCRIPTION
Motivation:

A user may not be able to download the package-list files due to network
restrictions.

Modifications:

- Add 'offlineJavadoc' option that skips automatic download of
  package-list files

Result:

- Can build behind the wall