### PR TITLE
Fix Javadoc package-list cache corruption

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -121,9 +121,12 @@ allprojects {
                 }
 
                 def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
+                def tmpPackageListFile = new File(javadocCacheDir, "${name}/${javadocUrlSha1}/package-list.tmp")
                 def packageListFile = new File(javadocCacheDir, "${name}/${javadocUrlSha1}/package-list")
-                if (!packageListFile.exists() && !offlineJavadoc) {
+
+                if ((!packageListFile.exists() || packageListFile.length() == 0) && !offlineJavadoc) {
                     packageListFile.parentFile.mkdirs()
+                    packageListFile.delete()
                     def packageListUrl = new URL("${javadocUrl}package-list")
                     logger.lifecycle("Downloading: ${packageListUrl}")
                     try {
@@ -136,8 +139,10 @@ allprojects {
                         conn.setRequestProperty('Pragma', 'no-cache')
                         conn.setRequestProperty('User-Agent', "Gradle/${gradle.gradleVersion} (${project.group}:${project.ext.artifactId})")
                         conn.setUseCaches(false);
-                        packageListFile.withOutputStream { it << conn.inputStream }
+                        tmpPackageListFile.withOutputStream { it << conn.inputStream }
+                        tmpPackageListFile.renameTo(packageListFile);
                     } catch (e) {
+                        tmpPackageListFile.delete()
                         throw new GradleScriptException("${e}", e)
                     }
                 }


### PR DESCRIPTION
Motivation:

When java-javdoc.gradle fails to retrieve the 'package-list' file, it
can produce and cache a partial file which should not be cached.

Modifications:

- Download into a temporary file and move to the cache file only when
  successfully downloaded
- Re-download when the cached file is empty, which is likely a bad file

Result:

No more cache corruption