### PR TITLE
Do not load the osdetector plugin unnecessarily

### DIFF
--- a/lib/java-rpc-proto.gradle
+++ b/lib/java-rpc-proto.gradle
@@ -10,7 +10,6 @@ buildscript {
 configure(projectsWithFlags('java')) {
     // Add protobuf/gRPC support if there is src/*/proto
     if (project.ext.hasSourceDirectory('proto')) {
-        apply plugin: 'com.google.osdetector'
         apply plugin: com.google.protobuf.gradle.ProtobufPlugin
 
         protobuf {

--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -35,7 +35,6 @@ configure(projectsWithFlags('java')) {
                 srcDirs = [srcDirs]
             }
 
-            apply plugin: 'com.google.osdetector'
             def includeDirs = project.findProperty(sourceSet.getTaskName('', 'thriftIncludeDirs'))?: []
             if (!(includeDirs instanceof Iterable) || includeDirs instanceof CharSequence) {
                 includeDirs = [includeDirs]
@@ -58,7 +57,7 @@ configure(projectsWithFlags('java')) {
                         actualThriftPath =
                                 "${libDir}/thrift" +
                                 "/${project.findProperty('thriftVersion')?: '0.11'}" +
-                                "/thrift.${osdetector.classifier}"
+                                "/thrift.${rootProject.osdetector.classifier}"
                     }
 
                     srcDirs.each { srcDir ->


### PR DESCRIPTION
Motivation:

protobuf-gradle-plugin conflicts with osdetector plugin since 0.8.5.

Modifications:

- Do not load the osdetector plugin unless absolutely necessary.
- Use rootProject.osdetector which is often just enough.

Result:

No build error when upgraded protobuf-gradle-plugin to 0.8.5