### PR TITLE
Handle non-200 response code when fetching a package-list file

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -3,6 +3,7 @@ import java.security.MessageDigest
 def offlineJavadoc = rootProject.hasProperty('offlineJavadoc')
 def javadocCacheDir = new File(gradle.gradleUserHomeDir, 'caches/package-lists')
 def defaultStylesheetFile = new File(buildscript.sourceFile.parentFile, 'java-javadoc.css')
+def visitedUrls = new HashSet<String>()
 
 task cleanJavadocCache(type: Delete, group: 'Build', description: 'Deletes the javadoc cache directory.') {
     delete javadocCacheDir
@@ -120,6 +121,10 @@ allprojects {
                     javadocUrl += '/'
                 }
 
+                if (!visitedUrls.add(javadocUrl)) {
+                    return
+                }
+
                 def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
                 def tmpPackageListFile = new File(javadocCacheDir, "${name}/${javadocUrlSha1}/package-list.tmp")
                 def packageListFile = new File(javadocCacheDir, "${name}/${javadocUrlSha1}/package-list")
@@ -128,7 +133,7 @@ allprojects {
                     packageListFile.parentFile.mkdirs()
                     packageListFile.delete()
                     def packageListUrl = new URL("${javadocUrl}package-list")
-                    logger.lifecycle("Downloading: ${packageListUrl}")
+                    logger.lifecycle("Download ${packageListUrl}")
                     try {
                         // Set some fake headers for the web sites who blocks a URLConnection.
                         def conn = packageListUrl.openConnection() as HttpURLConnection
@@ -138,9 +143,20 @@ allprojects {
                         conn.setRequestProperty("Cache-Control", 'no-cache')
                         conn.setRequestProperty('Pragma', 'no-cache')
                         conn.setRequestProperty('User-Agent', "Gradle/${gradle.gradleVersion} (${project.group}:${project.ext.artifactId})")
-                        conn.setUseCaches(false);
-                        tmpPackageListFile.withOutputStream { it << conn.inputStream }
-                        tmpPackageListFile.renameTo(packageListFile);
+                        conn.setUseCaches(false)
+
+                        if (conn.responseCode == 200) {
+                            tmpPackageListFile.withOutputStream { it << conn.inputStream }
+                            if (tmpPackageListFile.length() == 0) {
+                                tmpPackageListFile.delete()
+                            } else {
+                                tmpPackageListFile.renameTo(packageListFile);
+                            }
+                        } else {
+                            logger.log(LogLevel.WARN, "Download failed: ${conn.responseCode} ${conn.responseMessage}")
+                        }
+
+                        conn.disconnect()
                     } catch (e) {
                         tmpPackageListFile.delete()
                         throw new GradleScriptException("${e}", e)


### PR DESCRIPTION
Motivation:

When a server that hosts a package-list file sends a non-200 response
such as 301, the script will repeatedly try to download it.

Modification:

- Keep the visited URLs so that bad URLs are not retried
- Handle non-200 responses as failure

Result:

Fixes unnecessary repeated network access