### PR TITLE
Use Task.doFirst() for compileThrift tasks

### DIFF
--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -49,7 +49,7 @@ configure(projectsWithFlags('java')) {
                 project.sourceSets[scope].java.srcDir javaOutputDir
                 project.sourceSets[scope].resources.srcDir jsonOutputDir
 
-                doLast {
+                doFirst {
                     def actualThriftPath
                     if (project.findProperty('thriftPath') != null) {
                         actualThriftPath = project.findProperty('thriftPath')


### PR DESCRIPTION
Motivation:

Thrift generation uses doLast() to add the code that generates Java
source code. This may be executed later than user-added doLast hooks,
which results in reversed execution order.

Modifications:

Use doFirst() instead of doLast()

Result:

User-added hooks are executed later.