### PR TITLE
Fix a bug where -linkoffline Javadoc options are not passed

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -121,15 +121,16 @@ allprojects {
                     javadocUrl += '/'
                 }
 
-                if (!visitedUrls.add(javadocUrl)) {
-                    return
-                }
-
                 def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
                 def tmpPackageListFile = new File(javadocCacheDir, "${name}/${javadocUrlSha1}/package-list.tmp")
                 def packageListFile = new File(javadocCacheDir, "${name}/${javadocUrlSha1}/package-list")
 
                 if ((!packageListFile.exists() || packageListFile.length() == 0) && !offlineJavadoc) {
+                    // Do not attempt to download more than once.
+                    if (!visitedUrls.add(javadocUrl)) {
+                        return
+                    }
+
                     packageListFile.parentFile.mkdirs()
                     packageListFile.delete()
                     def packageListUrl = new URL("${javadocUrl}package-list")


### PR DESCRIPTION
Motivation:

d3e3972c794c54e36ec2ba50472899b24927014a introduced a bug where
-linkoffline option is not added when a Javadoc URL is handled more than
once.

Modifications:

Skip adding '-linkoffline' option only when download really failed

Result:

'-linkoffline' option is specified correctly.