### PR TITLE
Remove the workarounds related with PGP signing

### DIFF
--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -132,43 +132,13 @@ configure(projectsWithFlags('bom')) {
                         return artifactA.compareTo(artifactB);
                     }
                 }
-
-                if (project.ext.isSigning()) {
-                    // Add the signature to pom.xml.
-                    pom.withXml {
-                        def outDir = project.file("${project.buildDir}/publications/bom")
-                        def pomFile = new File(outDir, 'pom-default.xml')
-                        def pomAscFile = new File(outDir, "${pomFile.name}.asc")
-
-                        writeTo(pomFile)
-
-                        def actualPomAscFile = signing.sign(pomFile).signatureFiles[0]
-                        if (actualPomAscFile != pomAscFile) {
-                            if (!actualPomAscFile.renameTo(pomAscFile)) {
-                                throw new IllegalStateException("failed to rename ${actualPomAscFile} to ${pomAscFile}")
-                            }
-                        }
-
-                        artifact(pomAscFile) {
-                            classifier = null
-                            extension = 'pom.asc'
-                        }
-
-                        // NB: No idea why, but Gradle does not publish an artifact when it's the only artifact
-                        // in a publication. We add /dev/null as a placeholder artifact to work around this
-                        // problem. However, this will not work on a non-UNIX which does not have /dev/null.
-                        def devNull = new File('/dev/null')
-                        if (!devNull.exists() || devNull.isFile() || devNull.isDirectory()) {
-                            throw new IllegalStateException('Cannot publish a BOM without /dev/null; try on UNIX.')
-                        }
-
-                        artifact(devNull) {
-                            classifier = null
-                            extension = '_'
-                        }
-                    }
-                }
             }
+        }
+    }
+
+    if (project.ext.isSigning()) {
+        signing {
+            sign publishing.publications
         }
     }
 

--- a/lib/java-publish.gradle
+++ b/lib/java-publish.gradle
@@ -1,13 +1,5 @@
-import java.nio.file.Files
-
 configure(projectsWithFlags('publish', 'java')) {
     def needsToPublishShadedJar = project.hasFlags('relocate')
-
-    if (project.ext.isSigning()) {
-        signing {
-            sign configurations.archives
-        }
-    }
 
     publishing {
         publications {
@@ -181,40 +173,6 @@ configure(projectsWithFlags('publish', 'java')) {
                 artifact(tasks.javadocJar) {
                     classifier = 'javadoc'
                 }
-
-                // Add the .asc signatures.
-                if (project.ext.isSigning()) {
-                    // Add the signature to pom.xml.
-                    pom.withXml {
-                        def tmpDir = project.file("${project.buildDir}/publications/tmp")
-                        project.mkdir(tmpDir)
-                        def tmpPomFile = Files.createTempFile(tmpDir.toPath(), 'pom-', '.xml').toFile()
-                        writeTo(tmpPomFile)
-                        def pomAscFile = signing.sign(tmpPomFile).signatureFiles[0]
-                        artifact(pomAscFile) {
-                            classifier = null
-                            extension = 'pom.asc'
-                        }
-                        tmpPomFile.delete()
-                    }
-
-                    // Add the signature to the main JAR.
-                    artifact(new File("${mainJarFile}.asc")) {
-                        extension = 'jar.asc'
-                    }
-
-                    // Add the signature to the sources JAR.
-                    artifact(new File("${tasks.sourceJar.archivePath}.asc")) {
-                        classifier = 'sources'
-                        extension = 'jar.asc'
-                    }
-
-                    // Add the signature to the javadoc JAR.
-                    artifact(new File("${tasks.javadocJar.archivePath}.asc")) {
-                        classifier = 'javadoc'
-                        extension = 'jar.asc'
-                    }
-                }
             }
 
             jar(MavenPublication, configureJarPublication.curry(false))
@@ -225,24 +183,8 @@ configure(projectsWithFlags('publish', 'java')) {
     }
 
     if (project.ext.isSigning()) {
-        model {
-            tasks.publishJarPublicationToMavenLocal {
-                dependsOn(project.tasks.signArchives)
-            }
-            tasks.publishJarPublicationToMavenRepository {
-                dependsOn(project.tasks.signArchives)
-            }
-            if (needsToPublishShadedJar) {
-                tasks.publishShadedJarPublicationToMavenLocal {
-                    dependsOn(project.tasks.signArchives)
-                }
-                tasks.publishShadedJarPublicationToMavenRepository {
-                    dependsOn(project.tasks.signArchives)
-                }
-            }
-            tasks.signArchives {
-                onlyIf { rootProject.ext.isSigning() }
-            }
+        signing {
+            sign publishing.publications
         }
     }
 }

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -130,19 +130,10 @@ configure(relocatedProjects) {
 
         tasks.assemble.dependsOn tasks.trimShadedJar
 
-        // Add the trimmed JAR to archives so that the 'signArchives' task signs it.
+        // Add the trimmed JAR to archives.
         artifacts {
             trimShadedJar.outJarFiles.each {
                 archives it
-            }
-        }
-
-        // Make sure trimShadedJar task is executed before signing.
-        if (project.ext.isSigning()) {
-            model {
-                tasks.signArchives {
-                    dependsOn tasks.trimShadedJar
-                }
             }
         }
     }

--- a/settings-flags.gradle
+++ b/settings-flags.gradle
@@ -1,5 +1,12 @@
 import static java.util.Objects.requireNonNull
 
+// Ensure the Gradle version first of all.
+GradleVersion minimumSupportedGradleVersion = GradleVersion.version('4.8')
+if (GradleVersion.current() < minimumSupportedGradleVersion) {
+    throw new IllegalStateException("${minimumSupportedGradleVersion} or above is required to build this project.")
+}
+
+// Add the 'includeWithFlags' directive to 'settings'.
 ext.includeWithFlags = this.&includeWithFlags
 
 def includeWithFlags(CharSequence path, ...flags) {


### PR DESCRIPTION
Motivation:

Since 4.8, Gradle provides a simple way to sign all publications and
their POMs automatically.

Modifications:

- Replace the workarounds related with PGP signing with the way
  recommended by Gradle
- Fail the build early if the Gradle version is older than 4.8

Result:

- Simplicity