### PR TITLE
Fix Java 9/10 compatibility issues

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -105,14 +105,25 @@ allprojects {
             stylesheetFile = defaultStylesheetFile
 
             // Enable all lints except the missing tag warnings
-            addBooleanOption('Xdoclint:all').value = true
-            addBooleanOption('Xdoclint:-missing').value = true
+            addBooleanOption('Xdoclint:accessibility').value = true
+            addBooleanOption('Xdoclint:html').value = true
+            addBooleanOption('Xdoclint:reference').value = true
+            addBooleanOption('Xdoclint:syntax').value = true
+
+            // Enable HTML5 if possible.
+            if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+                addBooleanOption('html5').value = true
+            }
 
             // Add --allow-script-in-comments if available (since 1.8.0_121)
             try {
-                if (Class.forName('com.sun.tools.doclets.formats.html.ConfigurationImpl')
-                        .newInstance().optionLength('--allow-script-in-comments') > 0) {
+                if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
                     addBooleanOption('-allow-script-in-comments').value = true
+                } else {
+                    if (Class.forName('com.sun.tools.doclets.formats.html.ConfigurationImpl')
+                            .newInstance().optionLength('--allow-script-in-comments') > 0) {
+                        addBooleanOption('-allow-script-in-comments').value = true
+                    }
                 }
             } catch (ignored) {}
 

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -116,7 +116,16 @@ configure(relocatedProjects) {
                 }
             }
             libraryjars files(dependencyJars)
-            libraryjars file("${System.getProperty('java.home')}/lib/rt.jar")
+
+            // Add JDK. Use modules instead of rt.jar if possible.
+            File jmodDir = file("${System.getProperty('java.home')}/jmods")
+            if (jmodDir.isDirectory()) {
+                jmodDir.listFiles().findAll { File f ->
+                    f.isFile() && f.name.toLowerCase(Locale.ENGLISH).endsWith(".jmod")
+                }.each { libraryjars it }
+            } else {
+                libraryjars file("${System.getProperty('java.home')}/lib/rt.jar")
+            }
 
             dontoptimize
             dontobfuscate


### PR DESCRIPTION
- Use HTML5 Javadoc by default if Java version is 9+
- Specify `--allow-script-in-comments` explicitly for Java 9+
- Sepcify individual `Xdoclint` options so that `-missing` option is not
  ignored by some Javadoc versions
- Specify `.jmod` files instead of `rt.jar` when trimming a shaded JAR

This is a preparatory step to fix Armeria build issues with JDK 10. /cc @imasahiro