### PR TITLE
Improve Javadoc CSS

### DIFF
--- a/lib/java-javadoc.css
+++ b/lib/java-javadoc.css
@@ -893,35 +893,84 @@ table.striped > tbody > tr > th {
 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700,700i');
 @import url('https://fonts.googleapis.com/css?family=Inconsolata:400,700');
 
-/* Change the default font from DejaVu Serif to Source Sans Pro. */
-body,
-div.block,
-.contentContainer .description dl dd, .contentContainer .details dl dd, .serializedFormContainer dl dd,
+/* Reset font styles, from http://meyerweb.com/eric/tools/css/reset/ */
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+    font-size: 100%;
+    font-family: inherit;
+}
+
+/* Reset font styles defined in the original CSS. */
+body, pre, code, tt, dt code, table tr td dt code, sup,
+.aboutLanguage, .bar, .topNav, .bottomNav, .subNav, .indexNav, .indexNav h1,
+.header ul li, .footer ul li, .indexContainer, .indexContainer h2,
 .contentContainer .description dl dt, .contentContainer .details dl dt, .serializedFormContainer dl dt,
-.deprecationBlock,
-.topNav, .bottomNav, .subNav,
-td.colFirst, th.colFirst, td.colSecond, th.colSecond, td.colLast,
-th.colConstructorName, th.colDeprecatedItemName, th.colLast {
+.contentContainer .description dl dd, .contentContainer .details dl dd, .serializedFormContainer dl dd,
+.serializedFormContainer dl.nameValue dt, .serializedFormContainer dl.nameValue dd,
+td.colFirst, th.colFirst,
+td.colSecond, th.colSecond, td.colLast, th.colConstructorName, th.colDeprecatedItemName, th.colLast,
+.constantsSummary th, .packagesSummary th,
+.providesSummary th.colFirst, .providesSummary th.colLast, .providesSummary td.colFirst,
+.providesSummary td.colLast,
+ul.horizontal li, div.block, h1.hidden,
+.deprecationBlock, .ui-autocomplete-category, .resultItem,
+.searchTagDescResult, .searchTagHolderResult,
+table.striped > caption {
+    font-size: 100%;
+    font-family: inherit;
+}
+
+/* Change the default font from DejaVu Serif to Source Sans Pro. */
+body {
   font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
   /* .. and increase the font size a little bit for readability. */
   font-size: 15px;
 }
 
 /* Change the default monospace font from DejaVu Sans Mono to Inconsolata. */
-pre,
-code, tt,
-dt code,
-table tr td dt code {
+pre, code, tt {
   font-family: 'Inconsolata', 'Consolas', 'Menlo', 'Monaco', 'Lucida Console', 'Liberation Mono',
                'DejaVu Sans Mono', monospace;
-  /* .. and increase the font size a little bit for readability. */
-  font-size: 15px;
 }
 
-/* Increase the font size of the index. */
-.bar, .indexNav, .indexContainer, .indexContainer h2 {
-  font-size: 14px;
+/* Reset the heading styles. */
+h1 {
+  font-size: 1.6em;
 }
+h2 {
+  font-size: 1.3em;
+}
+h3 {
+  font-size: 1.1em;
+}
+h4, h5, h6 {
+  font-size: 1.0em;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-style: inherit;
+  margin-top: 9px;
+  margin-bottom: 7px;
+}
+
+/* Override the font styles of jQuery UI.
+ * Using !important because jQuery CSS is loaded later. */
+.ui-widget {
+  font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif !important;
+  font-size: 100% !important;
+}
+
+/* Adjust the padding of the class index frame. */
 .bar {
   padding-top: .4em;
 }
@@ -934,13 +983,33 @@ a[name]:before, a[name]:target, a[id]:before, a[id]:target {
   display: inline;
 }
 
+/* Remove the decoration around the block list and add separators between blocks. */
+ul.blockList ul.blockList li.blockList, ul.blockList ul.blockListLast li.blockList {
+  padding: 0;
+  border: none;
+  background-color: inherit;
+  border-top: solid 1px #c0c0c0;
+}
+
+/* Make <hr/> look same with block separators. */
+hr {
+  border: none;
+  border-top: solid 1px #c0c0c0;
+  margin: 1em 0;
+}
+
+/* Remove the space between a heading and a table caption. */
+.memberSummary caption {
+  padding-top: 0px;
+}
+
 /* Reduce the horizontal space around the navbars. */
 .topNav, .bottomNav {
   padding-top: 7px;
   height: 36px;
 }
 .subNav {
-  height: 29px;
+  height: 30px;
 }
 ul.navListSearch li {
   padding: 4px 1px 0px 0px;
@@ -988,6 +1057,11 @@ td.colOne, td.colFirst, td.colLast, .useSummary td, .constantsSummary td {
   word-break: normal;
   hyphens: auto;
   overflow-wrap: normal;
+}
+
+/* Reduce the left margin of the copyright footer. */
+.legalCopy {
+  margin-left: 0.3em;
 }
 /* Customization ends */
 


### PR DESCRIPTION
- Consistent font size
- Use consistent font family and size for search result
- Remove the background and padding around the blocks (method summary,
  method detail, ..)
  - Insert a separator between blocks instead
- Micellaneous tweaks

![screenshot_2018-07-17 serverbuilder armeria 0 67 3-snapshot api reference](https://user-images.githubusercontent.com/173918/42798798-5bf9d068-89d0-11e8-9fa3-d3875c7adf19.png)
