### PR TITLE
Fix deprecation warning in common-wrapper.gradle

### DIFF
--- a/lib/common-wrapper.gradle
+++ b/lib/common-wrapper.gradle
@@ -1,3 +1,3 @@
-task wrapper(type: Wrapper) {
+tasks.withType(Wrapper) {
     distributionType = Wrapper.DistributionType.ALL
 }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:

    Creating a custom task named 'wrapper' has been deprecated
    and is scheduled to be removed in Gradle 5.0. You can
    configure the existing task using the 'wrapper { }' syntax
    or create your custom task under a different name.'.