### PR TITLE
Add gen-src/*/{java,resources} to the source sets for all Java projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,16 @@ All projects will get the following extension properties:
 
 - `copyrightFooter` - the copyright footer HTML fragment generated from
   `inceptionYear`, `authorUrl` and `authorName` in `gradle.properties`
-
   - e.g. `&copy; Copyright 2015&ndash;2018 <a href="https://john.doe.com/">John Doe</a>. All rights reserved.`
-
 - `gitPath` - the path to the `git` command. `null` if Git is not available.
 - `executeGit(...args)` - executes a Git command with the specified arguments
+- `hasSourceDirectory(name)` - tells if the project has any source directory that matches `<projectDir>/src/*/<name>`, e.g.
+
+  ```java
+  if (project.ext.hasSourceDirectory('thrift')) {
+      println "${project} contains Thrift source files."
+  }
+  ```
 
 ## Using flags
 

--- a/build-flags.gradle
+++ b/build-flags.gradle
@@ -7,6 +7,7 @@ apply from: "${libDir}/common-info.gradle"
 apply from: "${libDir}/common-publish.gradle"
 apply from: "${libDir}/common-release.gradle"
 apply from: "${libDir}/common-wrapper.gradle"
+apply from: "${libDir}/common-misc.gradle"
 
 if (!projectsWithFlags('bom').isEmpty()) {
     apply from: "${libDir}/bom.gradle"
@@ -16,7 +17,6 @@ if (!projectsWithFlags('java').isEmpty()) {
     apply from: "${libDir}/java.gradle"
     apply from: "${libDir}/java-javadoc.gradle"
     apply from: "${libDir}/java-alpn.gradle"
-    apply from: "${libDir}/java-rpc.gradle"
     apply from: "${libDir}/java-rpc-thrift.gradle"
 
     if (projectsWithFlags('java').find { it.ext.hasSourceDirectory('proto') }) {

--- a/lib/common-misc.gradle
+++ b/lib/common-misc.gradle
@@ -4,17 +4,6 @@ allprojects {
     }
 }
 
-configure(projectsWithFlags('java')) {
-    ext {
-        genSrcDir = "${projectDir}/gen-src"
-    }
-
-    // Delete the generated source directory on clean.
-    clean {
-        delete project.ext.genSrcDir
-    }
-}
-
 static boolean hasSourceDirectory(Project project, String name) {
     return new File(project.projectDir, 'src').listFiles(new FileFilter() {
         @Override

--- a/lib/java-rpc-proto.gradle
+++ b/lib/java-rpc-proto.gradle
@@ -44,11 +44,9 @@ configure(projectsWithFlags('java')) {
             }
         }
 
-        // Add the generated source directories to the source set.
+        // Add the generated 'grpc' directories to the source sets.
         project.sourceSets.all { sourceSet ->
-            sourceSet.java.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/java")
             sourceSet.java.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/grpc")
-            sourceSet.resources.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/resources")
         }
 
         // Make sure protoc runs before the resources are copied so that .dsc files are included.

--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -46,8 +46,6 @@ configure(projectsWithFlags('java')) {
                 includeDirs.each { inputs.dir it }
                 outputs.dir javaOutputDir
                 outputs.dir jsonOutputDir
-                project.sourceSets[scope].java.srcDir javaOutputDir
-                project.sourceSets[scope].resources.srcDir jsonOutputDir
 
                 doFirst {
                     def actualThriftPath

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -19,6 +19,20 @@ configure(projectsWithFlags('java')) {
 
     archivesBaseName = project.ext.artifactId
 
+    // Delete the generated source directory on clean.
+    ext {
+        genSrcDir = "${projectDir}/gen-src"
+    }
+    clean {
+        delete project.ext.genSrcDir
+    }
+
+    // Add the generated source directories to the source sets.
+    project.sourceSets.all { sourceSet ->
+        sourceSet.java.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/java")
+        sourceSet.resources.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/resources")
+    }
+
     // Set the sensible compiler options.
     tasks.withType(JavaCompile) {
         def task = delegate


### PR DESCRIPTION
Motivations:

A user sometimes wants to generate source code and add the generated
source directories to the source sets. We can add well known generated
source directories for the user.

Modifications:

- For all Java projects:
  - Set `project.ext.genSrcDir`
  - Add `${project.ext.genSrcDir}/*/{java,resources}` to the source sets
- Move `project.ext.hasSourceDirectory()` to `common-misc.gradle`

Result:

- A user does not need to add `gen-src/*/{java,resources}` to the source
  sets anymore, even if he or she does not use Thrift or gRPC.
- `hasSourceDirectory()` is available to all projects.