### PR TITLE
Allow to customize release tag

### DIFF
--- a/lib/common-release.gradle
+++ b/lib/common-release.gradle
@@ -68,7 +68,10 @@ task release(
                     "Git repository is not clean:${System.lineSeparator()}${gitStatusOut}")
         }
 
-        def tag = "$rootProject.name-$releaseVersion"
+        def tag = project.findProperty("tag")
+        if (tag == null) {
+            tag = "$rootProject.name-$releaseVersion"
+        }
 
         def gradlePropsFile = project.file("${project.projectDir}/gradle.properties")
         def gradlePropsContent = gradlePropsFile.getText('ISO-8859-1')


### PR DESCRIPTION
Motivations:
- Like other release plugins, better to support to customize release tag. 

Changes: 
- Check tag property and use it if exist. Otherwise use default tag name