### PR TITLE
Publish only shaded JARs if a project is shaded / Include project's o…

### DIFF
--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -53,83 +53,32 @@ configure(projectsWithFlags('bom')) {
                     if (dependencyMgmt == null) {
                         findChildNode(asNode(), 'scm') + {
                             resolveStrategy = DELEGATE_FIRST
-                            dependencyManagement {
-                                dependencies {
-                                    deleteMe {} // Placeholder to use the Node.plus(Closure)
-                                }
-                            }
+                            dependencyManagement {}
                         }
                         dependencyMgmt = findChildNode(asNode(), 'dependencyManagement')
                     }
 
-                    // Add our own projects to the 'dependencies' sections.
-                    List<Node> dependencies = findChildNode(dependencyMgmt, 'dependencies').children()
-                    dependencies.last() + {
+                    // Replace the `dependencyManagement` section populated by dependency-management-plugin
+                    // or created by ourselves above.
+                    dependencyMgmt.replaceNode {
                         resolveStrategy = DELEGATE_FIRST
-                        projectsWithFlags('java', 'publish').each { Project p ->
-                            dependency {
-                                groupId "${p.group}"
-                                artifactId "${p.ext.artifactId}"
-                                version "${p.version}"
-                            }
-                            if (p.hasFlags('relocate')) {
-                                dependency {
-                                    groupId "${p.group}"
-                                    artifactId "${p.ext.artifactId}-shaded"
-                                    version "${p.version}"
+                        dependencyManagement {
+                            dependencies {
+                                projectsWithFlags('java', 'publish').toList().sort { a, b ->
+                                    def groupComparison = "${a.group}".compareTo("${b.group}")
+                                    if (groupComparison != 0) {
+                                        return groupComparison
+                                    }
+                                    return "${a.ext.artifactId}".compareTo("${b.ext.artifactId}")
+                                }.each { p ->
+                                    dependency {
+                                        groupId "${p.group}"
+                                        artifactId "${p.ext.artifactId}"
+                                        version "${p.version}"
+                                    }
                                 }
                             }
                         }
-                    }
-
-                    // Remove the 'deleteMe' placeholder we added above.
-                    dependencies.removeIf {
-                        def name = it.name()
-                        if (name instanceof QName) {
-                            name = name.localPart
-                        } else {
-                            name = name.toString()
-                        }
-
-                        return name == 'deleteMe'
-                    }
-
-                    // Sort the dependencies for aesthetics.
-                    dependencies.sort { a, b ->
-                        // BOM import comes first.
-                        def scopeNodeA = findChildNode(a, 'scope')
-                        def scopeNodeB = findChildNode(b, 'scope')
-                        def scopeA = scopeNodeA != null ? scopeNodeA.text() : ''
-                        def scopeB = scopeNodeB != null ? scopeNodeB.text() : ''
-                        if (scopeA == 'import') {
-                            if (scopeB != 'import') {
-                                return -1
-                            }
-                        } else if (scopeB == 'import') {
-                            return 1
-                        }
-
-                        // Our own group comes first.
-                        def groupA = findChildNode(a, 'groupId').text()
-                        def groupB = findChildNode(b, 'groupId').text()
-                        if (groupA == rootProject.group) {
-                            if (groupB != rootProject.group) {
-                                return -1
-                            }
-                        } else if (groupB == rootProject.group) {
-                            return 1
-                        }
-
-                        // Sort by groupId alphabetically otherwise.
-                        def groupComparison = groupA.compareTo(groupB)
-                        if (groupComparison != 0) {
-                            return groupComparison
-                        }
-
-                        // Sort by artifactId.
-                        def artifactA = findChildNode(a, 'artifactId').text()
-                        def artifactB = findChildNode(b, 'artifactId').text()
-                        return artifactA.compareTo(artifactB);
                     }
                 }
             }

--- a/lib/java-publish.gradle
+++ b/lib/java-publish.gradle
@@ -1,14 +1,8 @@
 configure(projectsWithFlags('publish', 'java')) {
-    def needsToPublishShadedJar = project.hasFlags('relocate')
-
     publishing {
         publications {
-            def configureJarPublication = { boolean isShaded ->
+            jar(MavenPublication) {
                 def currentArtifactId = project.ext.artifactId
-                if (isShaded) {
-                    currentArtifactId += '-shaded'
-                }
-
                 artifactId currentArtifactId
 
                 // Generate the POM.
@@ -68,7 +62,7 @@ configure(projectsWithFlags('publish', 'java')) {
                             }).each { dep ->
                                 dependency {
                                     groupId dep.group
-                                    artifactId dep.dependencyProject.ext.artifactId + (isShaded ? '-shaded' : '')
+                                    artifactId dep.dependencyProject.ext.artifactId
                                     version dep.version ?: dep.dependencyProject.version
                                     if (dep.hasProperty('optional') && dep.optional) {
                                         optional true
@@ -88,7 +82,7 @@ configure(projectsWithFlags('publish', 'java')) {
                             }).each { dep ->
                                 dependency {
                                     groupId dep.group
-                                    artifactId dep.dependencyProject.ext.artifactId + (isShaded ? '-shaded' : '')
+                                    artifactId dep.dependencyProject.ext.artifactId
                                     version dep.version ?: dep.dependencyProject.version
                                     scope 'runtime'
                                     if (dep.hasProperty('optional') && dep.optional) {
@@ -112,7 +106,7 @@ configure(projectsWithFlags('publish', 'java')) {
                                 }
 
                                 if (unresolvedDep instanceof ExternalModuleDependency) {
-                                    if (isShaded && project.ext.relocations.find({
+                                    if (project.hasFlags('relocate') && project.ext.relocations.find({
                                         it.name == "${dep.moduleGroup}:${dep.moduleName}"
                                     })) {
                                         // Shaded dependency
@@ -148,17 +142,15 @@ configure(projectsWithFlags('publish', 'java')) {
                 // Find the main JAR and the task that generates it.
                 File mainJarFile
                 Task mainJarTask
-                if (!isShaded) {
+                if (tasks.findByName('trimShadedJar')) {
+                    mainJarFile = tasks.trimShadedJar.outJarFiles.find() as File
+                    mainJarTask = tasks.trimShadedJar
+                } else if (tasks.findByName('shadedJar')) {
+                    mainJarFile = tasks.shadedJar.archivePath
+                    mainJarTask = tasks.shadedJar
+                } else {
                     mainJarFile = tasks.jar.archivePath
                     mainJarTask = tasks.jar
-                } else {
-                    if (tasks.findByName('trimShadedJar')) {
-                        mainJarFile = tasks.trimShadedJar.outJarFiles.find() as File
-                        mainJarTask = tasks.trimShadedJar
-                    } else {
-                        mainJarFile = tasks.shadedJar.archivePath
-                        mainJarTask = tasks.shadedJar
-                    }
                 }
 
                 // Add the main JAR.
@@ -173,11 +165,6 @@ configure(projectsWithFlags('publish', 'java')) {
                 artifact(tasks.javadocJar) {
                     classifier = 'javadoc'
                 }
-            }
-
-            jar(MavenPublication, configureJarPublication.curry(false))
-            if (needsToPublishShadedJar) {
-                shadedJar(MavenPublication, configureJarPublication.curry(true))
             }
         }
     }

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -131,7 +131,7 @@ configure(relocatedProjects) {
             dontobfuscate
             dontwarn // Ignore the harmless 'missing classes' warnings related with the optional dependencies.
 
-            keepattributes 'Signature, InnerClasses, EnclosingMethod, *Annotation*'
+            keepattributes '**'
             keepparameternames
 
             printconfiguration file("${project.buildDir}/proguard.cfg")
@@ -191,6 +191,13 @@ configure(relocatedProjects) {
                 it.tasks.shadedTest.classpath +=
                         it.files(createShadedTestRuntimeConfiguration(it).resolve())
             }
+        }
+    }
+
+    gradle.taskGraph.whenReady {
+        // Skip unshaded tests if shaded tests will run.
+        if (gradle.taskGraph.hasTask(tasks.shadedTest)) {
+            tasks.test.onlyIf { false }
         }
     }
 }


### PR DESCRIPTION
…wn artifacts in BOM

Motivation:

- Publishing two versions (shaded and unshaded) of JARs for the same
  module can cause an unexpected trouble such as version conflict.
  - Related: https://github.com/line/armeria/issues/1435
- The BOM file generated by `lib/bom.gradle` contains:
  - Non-essential dependencies such as build-time dependencies
  - Unnecessary transitive dependencies of the project's own artifacts

Modifications:

- When publishing, publish the shaded JAR as the main JAR, which means:
  - Unshaded JARs are never published for the projects with `relocated`
    flag.
  - There are no more artifacts whose artifactId ends with `-shaded`.
- When running `gradle check`, the `test` task will not run its shaded
  version (i.e. `shadedTest`) is scheduled to run.
- The BOM file now contains only project's own artifacts.

Result:

- No chance of confusion by having both shaded and unshaded JARs in a
  project.
- Cleaner BOM file which does not contain unnecessary entries.