### PR TITLE
Fix build failure when measuring test coverage on a shaded module

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,17 +325,31 @@ When a project has a `java` flag:
 - Checkstyle validation is enabled using `checkstyle` plugin if Checkstyle
   configuration file exists at `<project_root>/settings/checkstyle/checkstyle.xml`
 
-    - A special configuration property `checkstyleConfigDir` is set so you can
-      access the external files such as `suppressions.xml` from `checkstyle.xml`.
-    - You can choose Checkstyle version by specifying it in `dependencies.yml`:
+  - A special configuration property `checkstyleConfigDir` is set so you can
+    access the external files such as `suppressions.xml` from `checkstyle.xml`.
+  - You can choose Checkstyle version by specifying it in `dependencies.yml`:
 
-      ```yaml
-      com.puppycrawl.tools:
-        checkstyle: { version: '8.5' }
-      ```
+    ```yaml
+    com.puppycrawl.tools:
+      checkstyle: { version: '8.5' }
+    ```
 
 - Test coverage report is enabled using `jacoco` plugin if `-Pcoverage` option
   is specified.
+
+  - You can exclude certain packages from the coverage report using the
+    `jacocoExclusions` property:
+
+    ```groovy
+    rootProject {
+        ext {
+            jacocoExclusions = [
+                '/com/example/generated/sources/**',
+                '/com/example/third/party/**'
+            ]
+        }
+    }
+    ```
 
 - [Jetty ALPN agent](https://github.com/jetty-project/jetty-alpn-agent) is
   loaded automatically when launching a Java process if you specified it in

--- a/build-flags.gradle
+++ b/build-flags.gradle
@@ -16,6 +16,7 @@ if (!projectsWithFlags('bom').isEmpty()) {
 if (!projectsWithFlags('java').isEmpty()) {
     apply from: "${libDir}/java.gradle"
     apply from: "${libDir}/java-javadoc.gradle"
+    apply from: "${libDir}/java-coverage.gradle"
     apply from: "${libDir}/java-alpn.gradle"
     apply from: "${libDir}/java-rpc-thrift.gradle"
 

--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -69,7 +69,10 @@ allprojects {
 
 // Create a new configuration called 'allDependencies'.
 rootProject.configurations {
-    allDependencies
+    allDependencies {
+        visible = false
+        transitive = false
+    }
 }
 
 // Add all dependencies declared in 'dependencies.yml' to 'allDependencies' because otherwise

--- a/lib/java-alpn.gradle
+++ b/lib/java-alpn.gradle
@@ -7,7 +7,9 @@ configure(projectsWithFlags('java')) {
     // Use Jetty ALPN agent if dependencyManagement mentions it.
     if (managedVersions.containsKey('org.mortbay.jetty.alpn:jetty-alpn-agent')) {
         configurations {
-            alpnAgent
+            alpnAgent {
+                visible = false
+            }
         }
 
         dependencies {

--- a/lib/java-coverage.gradle
+++ b/lib/java-coverage.gradle
@@ -1,0 +1,109 @@
+// Enable JaCoCo test coverage when '-Pcoverage' option is specified.
+def jacocoEnabled = project.hasProperty('coverage')
+if (!jacocoEnabled) {
+    return
+}
+
+// Collect JaCoCo execution data for all modules.
+configure(projectsWithFlags('java')) {
+    if (project.hasFlags('no_aggregation')) {
+        return;
+    }
+
+    apply plugin: 'jacoco'
+
+    project.addFlags('coverage')
+
+    tasks.withType(Test) {
+        jacoco {
+            enabled = true
+            append = false
+        }
+    }
+
+    // Do not generate per-module report; generate aggregated report only.
+    tasks.jacocoTestReport.configure {
+        onlyIf { false }
+    }
+}
+
+// Generate JaCoCo report from the collected execution data.
+configure(rootProject) {
+    configurations {
+        jacocoAnt {
+            visible = false
+        }
+    }
+
+    dependencies {
+        jacocoAnt "org.jacoco:org.jacoco.ant:${JacocoPlugin.DEFAULT_JACOCO_VERSION}"
+    }
+
+    task jacocoTestReport(type: JacocoReport) {
+        def reportTask = delegate
+        reports {
+            csv.enabled = false
+            xml.enabled = true
+            xml.destination = file("${rootProject.buildDir}/report/jacoco/jacocoTestReport.xml")
+            html.enabled = true
+            html.destination = file("${rootProject.buildDir}/report/jacoco/html")
+        }
+
+        jacocoClasspath = configurations.jacocoAnt
+
+        afterEvaluate {
+            // Set dependencies related with report generation and feed execution data.
+            projectsWithFlags('java', 'coverage').each { Project p ->
+                if (p.hasFlags('relocate')) {
+                    reportTask.dependsOn(p.tasks.shadedClasses)
+                }
+
+                p.tasks.withType(Test).each { testTask ->
+                    reportTask.dependsOn(testTask)
+                    reportTask.mustRunAfter(testTask)
+                    testTask.finalizedBy(reportTask)
+
+                    def dataFile = testTask.extensions.findByType(JacocoTaskExtension.class).destinationFile
+                    reportTask.doFirst {
+                        // Create an empty .exec file just in case the test task did not run.
+                        if (!dataFile.exists()) {
+                            dataFile.parentFile.mkdirs()
+                            try {
+                                dataFile.createNewFile()
+                            } catch (ignored) {}
+                        }
+                    }
+
+                    reportTask.executionData(testTask)
+                }
+            }
+
+            // Include all sources and classes directories so that the report includes other modules.
+            sourceDirectories = files(projectsWithFlags('java').inject([], { a, b ->
+                a + b.sourceSets.main.java.srcDirs.findAll { File srcDir ->
+                    // Exclude generated sources.
+                    return !srcDir.path.contains('/gen-src/') && !srcDir.path.contains('\\gen-src\\')
+                }
+            }))
+            classDirectories = files(projectsWithFlags('java').inject([], { a, b ->
+                if (b.hasFlags('no_aggregation')) {
+                    return a
+                }
+                if (b.hasFlags('relocate')) {
+                    return a + [b.tasks.shadedClasses.destinationDir]
+                }
+                return a + b.sourceSets.main.output.classesDirs
+            }))
+
+            // Exclude shaded classes from the report.
+            def exclusions = rootProject.ext.relocations.collect { "/${it['to'].replace('.', '/')}/**" }
+            def additionalExclusions = rootProject.findProperty('jacocoExclusions');
+            if (additionalExclusions) {
+                additionalExclusions.each { exclusions.add("${it}") }
+            }
+            classDirectories = files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: exclusions)
+            })
+        }
+    }
+}

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -20,7 +20,7 @@ configure(relocatedProjects) {
     task shadedJar(
             type: ShadowJar,
             group: 'Build',
-            description: 'Builds the shaded JAR.',
+            description: 'Builds the shaded main JAR.',
             dependsOn: tasks.classes) {
 
         configureShadowTask(project, delegate, true)
@@ -37,6 +37,20 @@ configure(relocatedProjects) {
 
     artifacts {
         archives shadedJar
+    }
+
+    task shadedClasses(
+            type: Copy,
+            group: 'Build',
+            description: 'Extracts the shaded main JAR.',
+            dependsOn: tasks.shadedJar) {
+
+        from(zipTree(tasks.shadedJar.archivePath))
+        from(sourceSets.main.output.classesDirs) {
+            // Add the JAR resources excluded in the 'shadedJar' task.
+            include '**/*.jar'
+        }
+        into "${project.buildDir}/classes/java/shaded-main"
     }
 
     task shadedTestJar(
@@ -173,12 +187,6 @@ configure(relocatedProjects) {
 
         project.ext.relocations.each {
             exclude "${it['to'].replace('.', '/')}/**"
-        }
-
-        if (project.hasFlags('coverage')) {
-            jacoco {
-                enabled = false
-            }
         }
     }
     tasks.check.dependsOn tasks.shadedTest

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -3,9 +3,6 @@ def checkstyleConfigDir = "${rootProject.projectDir}/settings/checkstyle"
 def checkstyleEnabled = new File(checkstyleConfigDir).isDirectory() &&
                         new File("${checkstyleConfigDir}/checkstyle.xml").isFile()
 
-// Enable JaCoCo test coverage when '-Pcoverage' option is specified.
-def jacocoEnabled = project.hasProperty('coverage')
-
 configure(rootProject) {
     apply plugin: 'eclipse'
     apply plugin: 'idea'
@@ -112,42 +109,6 @@ configure(projectsWithFlags('java')) {
 
         test {
             dependsOn tasks.checkstyle
-        }
-    }
-
-    // Generate JaCoCo reports.
-    if (jacocoEnabled && !project.hasFlags('no_aggregation')) {
-        apply plugin: 'jacoco'
-
-        project.addFlags('coverage')
-
-        tasks.withType(Test) {
-            jacoco {
-                enabled = true
-                append = false
-            }
-        }
-
-        jacocoTestReport {
-            reports {
-                csv.enabled = false
-                xml.enabled = true
-                html.enabled = true
-            }
-
-            afterEvaluate {
-                // Include all sources and classes directories so that the report includes other modules.
-                sourceDirectories = files(projectsWithFlags('java').inject([], { a, b ->
-                    a + b.sourceSets.main.java.srcDirs }
-                ))
-                classDirectories = files(projectsWithFlags('java').inject([], { a, b ->
-                    b.hasFlags('no_aggregation') ? a : a + b.sourceSets.main.output.classesDirs
-                }))
-            }
-        }
-
-        tasks.withType(Test) {
-            finalizedBy tasks.jacocoTestReport
         }
     }
 }


### PR DESCRIPTION
Motivation:

JaCoCo report task fails when a project contains a shaded module.

Modifications:

- Made sure JaCoCo execution data file exists even if tests did not run
  to make the report task happy.
- JaCoCo report is not generated per module anymore. An aggregated
  report is generated by the root project for more accurate numbers.
- Chose a correct class directory for a shaded module.
  - Added a new task `shadedClasses`
- Miscellaneous:
  - Hid configurations that are not useful to users.

Result:

- Build does not fail anymore when a user specified `-Pcoverage` flag.