### PR TITLE
Add `afterProjectsWithFlag(s)` / Configure `jacocoTestReport` after all Java projects are evaluated

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,11 @@ configure(projectsWithFlags('java')) {
 }
 
 // Running a certain task after all Java projects are evaluated:
-afterProjectsWithFlag('java') {
-    println 'All Java projects have been evaluated.'
+afterProjectsWithFlag('java') { Set<Project> projects ->
+    println 'All Java projects have been evaluated: ${projects}'
 }
-afterProjectsWithFlags(['java', 'relocated']) {
-    println 'All Java projects with class relocation have been evaluated.'
+afterProjectsWithFlags(['java', 'relocated']) { Set<Project> projects ->
+    println 'All Java projects with class relocation have been evaluated: ${projects}'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ configure(projectsWithFlags('java')) {
         println "A Java project '${project.path}' will be published to a Maven repository."
     }
 }
+
+// Running a certain task after all Java projects are evaluated:
+afterProjectsWithFlag('java') {
+    println 'All Java projects have been evaluated.'
+}
+afterProjectsWithFlags(['java', 'relocated']) {
+    println 'All Java projects with class relocation have been evaluated.'
+}
 ```
 
 If you added the snippet above to `build.gradle`, `./gradlew` will show the

--- a/lib/java-coverage.gradle
+++ b/lib/java-coverage.gradle
@@ -51,9 +51,9 @@ configure(rootProject) {
 
         jacocoClasspath = configurations.jacocoAnt
 
-        afterEvaluate {
+        afterProjectsWithFlags(['java', 'coverage']) { projects ->
             // Set dependencies related with report generation and feed execution data.
-            projectsWithFlags('java', 'coverage').each { Project p ->
+            projects.each { Project p ->
                 if (p.hasFlags('relocate')) {
                     reportTask.dependsOn(p.tasks.shadedClasses)
                 }

--- a/settings-flags.gradle
+++ b/settings-flags.gradle
@@ -1,3 +1,5 @@
+import java.util.concurrent.ConcurrentHashMap
+
 import static java.util.Objects.requireNonNull
 
 // Ensure the Gradle version first of all.
@@ -29,6 +31,8 @@ def includeWithFlags(CharSequence path, ...flags) {
                 p.ext.hasFlag = p.ext.hasFlags = this.&hasFlags.curry(p)
                 p.ext.assertFlag = p.ext.assertFlags = this.&assertFlags.curry(p)
                 p.ext.projectsWithFlag = p.ext.projectsWithFlags = this.&projectsWithFlags.curry(p)
+                p.ext.afterProjectsWithFlag = this.&afterProjectsWithFlag.curry(p)
+                p.ext.afterProjectsWithFlags = this.&afterProjectsWithFlags.curry(p)
                 p.ext.addFlag = p.ext.addFlags = { args -> p.ext.flags = addFlags(p.ext.flags, args) }
             }
         }
@@ -121,4 +125,23 @@ static def projectsWithFlags(Project project, ...flags) {
             project.rootProject.allprojects.findAll {
                 it.ext.has('hasFlags') && it.ext.hasFlags(flags)
             })
+}
+
+static void afterProjectsWithFlag(Project project, Object flag, Closure<Set<Project>> closure) {
+    afterProjectsWithFlags(project, [flag], closure)
+}
+
+static void afterProjectsWithFlags(Project project, Iterable<?> flags, Closure<Set<Project>> closure) {
+    def projects = projectsWithFlags(project, flags)
+    def remainingProjects = Collections.newSetFromMap(new ConcurrentHashMap<Project, Boolean>())
+    remainingProjects.addAll(projects)
+
+    projects.each { p ->
+        p.afterEvaluate {
+            remainingProjects.remove(p);
+            if (remainingProjects.isEmpty()) {
+                closure(projects)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

Currently, `jacocoTestReport` task is not configured late enough so that
some test tasks are not included in the report automatically.

Modifications:

- Add a new utility method `afterProjectsWithFlags` which allows us to
  register a callback which is invoked when the projects with certain
  flags are all evaluated.
- Configure `jacocoTestReport` only after all Java projects are
  evaluated.

Result:

- `jacocoTestReport` now picks up all test tasks, even the ones defined
  in the subprojects.