### PR TITLE
Fix deprecation warning in lib/java-rpc-thrift.gradle

### DIFF
--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -25,8 +25,8 @@ configure(projectsWithFlags('java')) {
             if (srcDirs == null) {
                 def defaultSrcDir = "${projectDir}/src/${scope}/thrift"
                 if (!project.file(defaultSrcDir).isDirectory()) {
-                    // Remove the compile*Thrift task which turned out to be unnecessary.
-                    project.tasks.remove(task)
+                    // Disable the compile*Thrift task which turned out to be unnecessary.
+                    task.enabled = false
                     return
                 }
                 srcDirs = [defaultSrcDir]


### PR DESCRIPTION
Use `Task.setEnabled()` instead of `TaskContainer.remove()`.