### PR TITLE
Use `element-list` for Java 10+

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -25,6 +25,7 @@ allprojects {
               var l = document.links[i];
               if (l.href && l.href.indexOf("?is-external=true") >= 0) {
                 l.target = "_blank";
+                l.rel = "noopener";
               }
             }
             </script>
@@ -197,24 +198,35 @@ allprojects {
                     elementListFile.delete()
                 }
 
-                def success = true
-                if (!packageListFile.exists()) {
-                    if (!downloadListFile(packageListFile, new URL("${javadocUrl}package-list"))) {
+                def success = packageListFile.exists() ||
+                              JavaVersion.current() >= JavaVersion.VERSION_1_10 && elementListFile.exists()
+                if (!success) {
+                    if (downloadListFile(packageListFile, new URL("${javadocUrl}package-list"))) {
+                        // Succeeded to download package-list.
+                        success = true
+                    } else {
                         // Failed to download package-list, try element-list.
-                        if (downloadListFile(elementListFile, new URL("${javadocUrl}element-list"))) {
-                            // package-list does not exist, but element-list exists.
-                            // No problem. We can generate package-list from element-list.
-                            def tmpPackageListFile = new File("${packageListFile}.tmp")
-                            tmpPackageListFile.withWriter('utf-8') { out ->
-                                // Find only the lines with a package name.
-                                elementListFile.filterLine(out, 'utf-8') { line ->
-                                    def packageNamePattern = /^\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*(?:\.\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*)*$/
-                                    return line.matches(packageNamePattern)
-                                }
-                            }
-                            success = tmpPackageListFile.renameTo(packageListFile)
-                        } else {
+                        if (!downloadListFile(elementListFile, new URL("${javadocUrl}element-list"))) {
+                            // Failed to download both package-list and element-list.
                             success = false
+                        } else {
+                            // package-list does not exist, but element-list exists.
+                            if (JavaVersion.current() >= JavaVersion.VERSION_1_10) {
+                                // Java 10+ supports element-list. Use it as-is.
+                                success = true
+                            } else {
+                                // Java older than 10 does not support element-list.
+                                // No problem. We can generate package-list from element-list.
+                                def tmpPackageListFile = new File("${packageListFile}.tmp")
+                                tmpPackageListFile.withWriter('utf-8') { out ->
+                                    // Find only the lines with a package name.
+                                    elementListFile.filterLine(out, 'utf-8') { line ->
+                                        def packageNamePattern = /^\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*(?:\.\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*)*$/
+                                        return line.matches(packageNamePattern)
+                                    }
+                                }
+                                success = tmpPackageListFile.renameTo(packageListFile)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Motivation:

When building with Java 11, Javadoc may fail when you specify
`package-list` converted from `element-list`.

Modifications:

- Use `element-list` for Java 10+.
- Convert `element-list` into `package-list` only when really necessary.

Result:

Builds OK on Java 11.