### PR TITLE
Add more languages to Highlight.js

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -30,6 +30,9 @@ allprojects {
             }
             </script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/gradle.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/protobuf.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/thrift.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/yaml.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.6.0/highlightjs-line-numbers.min.js"></script>
             <script>
@@ -59,12 +62,6 @@ allprojects {
             }
 
             var hasHljs = typeof hljs !== "undefined";
-            if (hasHljs) {
-              hljs.configure({
-                languages: [ "java", "xml", "json", "yaml", "shell" ]
-              });
-            }
-
             var allPres = document.getElementsByTagName("PRE");
             for (var i in allPres) {
               if (typeof allPres[i].children === "undefined") {


### PR DESCRIPTION
- Added `gradle`, `protobuf` and `thrift`
- Removed the language autodetection restriction because autodetection
  seems to work fine without restriction and a user can specify language
  using a `class` attribute.