### PR TITLE
Fix a bug where JDK 11 API are not linked properly when creating Javadoc

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -176,31 +176,26 @@ allprojects {
 
             def addJdk11OfflineLink = { name, url, elementListFile ->
                 def modulePrefix = 'module:';
-                def inModule = false
                 def currentModule = ''
                 List<String> lines = []
                 elementListFile.eachLine { line ->
                     if (line.startsWith(modulePrefix)) {
-                        if (inModule) {
-                            inModule = false;
-                            if (!lines.isEmpty()) {
-                                def javadocUrl = "${url}${currentModule}/"
-                                def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
-                                def listFileDir = new File(javadocCacheDir, "${name}/${currentModule}/${javadocUrlSha1}")
-                                def moduleElementListFile = new File(listFileDir, 'element-list')
-                                moduleElementListFile.parentFile.mkdirs()
-                                moduleElementListFile.withWriter { out ->
-                                    lines.each {
-                                        out.println it
-                                    }
+                        if (!lines.isEmpty()) {
+                            def javadocUrl = "${url}${currentModule}/"
+                            def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
+                            def listFileDir = new File(javadocCacheDir, "${name}/${currentModule}/${javadocUrlSha1}")
+                            def moduleElementListFile = new File(listFileDir, 'element-list')
+                            moduleElementListFile.parentFile.mkdirs()
+                            moduleElementListFile.withWriter { out ->
+                                lines.each {
+                                    out.println it
                                 }
-
-                                linksOffline javadocUrl, "${listFileDir}"
                             }
-                        } else {
-                            currentModule = line.substring(modulePrefix.length())
-                            inModule = true;
+
+                            linksOffline javadocUrl, "${listFileDir}"
+                            lines.clear()
                         }
+                        currentModule = line.substring(modulePrefix.length())
                     } else {
                         lines += line
                     }
@@ -264,7 +259,7 @@ allprojects {
 
                 if (success) {
                     if ('java11' == name) {
-                        // From Java 11+ API docs, we have to add the module name to URLs. 
+                        // From Java 11+ API docs, we have to add the module name to URLs.
                         addJdk11OfflineLink(name, url, elementListFile)
                     } else {
                         linksOffline javadocUrl, "${listFileDir}"

--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -183,7 +183,7 @@ allprojects {
                     if (line.startsWith(modulePrefix)) {
                         if (inModule) {
                             inModule = false;
-                            if (lines.size() != 0) {
+                            if (!lines.isEmpty()) {
                                 def javadocUrl = "${url}${currentModule}/"
                                 def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
                                 def listFileDir = new File(javadocCacheDir, "${name}/${currentModule}/${javadocUrlSha1}")

--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -174,6 +174,39 @@ allprojects {
                 return success
             }
 
+            def addJdk11OfflineLink = { name, url, elementListFile ->
+                def modulePrefix = 'module:';
+                def inModule = false
+                def currentModule = ''
+                List<String> lines = []
+                elementListFile.eachLine { line ->
+                    if (line.startsWith(modulePrefix)) {
+                        if (inModule) {
+                            inModule = false;
+                            if (lines.size() != 0) {
+                                def javadocUrl = "${url}${currentModule}/"
+                                def javadocUrlSha1 = MessageDigest.getInstance('SHA1').digest(javadocUrl.getBytes('UTF-8')).encodeHex()
+                                def listFileDir = new File(javadocCacheDir, "${name}/${currentModule}/${javadocUrlSha1}")
+                                def moduleElementListFile = new File(listFileDir, 'element-list')
+                                moduleElementListFile.parentFile.mkdirs()
+                                moduleElementListFile.withWriter { out ->
+                                    lines.each {
+                                        out.println it
+                                    }
+                                }
+
+                                linksOffline javadocUrl, "${listFileDir}"
+                            }
+                        } else {
+                            currentModule = line.substring(modulePrefix.length())
+                            inModule = true;
+                        }
+                    } else {
+                        lines += line
+                    }
+                }
+            }
+
             def addOfflineLink = { name, url ->
                 if (offlineJavadoc) {
                     return
@@ -230,7 +263,12 @@ allprojects {
                 }
 
                 if (success) {
-                    linksOffline javadocUrl, "${listFileDir}"
+                    if ('java11' == name) {
+                        // From Java 11+ API docs, we have to add the module name to URLs. 
+                        addJdk11OfflineLink(name, url, elementListFile)
+                    } else {
+                        linksOffline javadocUrl, "${listFileDir}"
+                    }
                 }
             }
 


### PR DESCRIPTION
Motivation:
From Java 11 API docs, the URL contains module name, so we should fix it.

Modifications:

- Add the module name to URLs.

Result:

- You can now link to the Java 11 API docs from the Javadoc generated.