### PR TITLE
Do not perform PGP-signing when building on JitPack.

### DIFF
--- a/lib/common-publish.gradle
+++ b/lib/common-publish.gradle
@@ -1,9 +1,14 @@
 def isReleaseVersion = !(rootProject.version.endsWith('-SNAPSHOT'))
-def publishSignatureRequired = ('true' == rootProject.findProperty('publishSignatureRequired'))
+def publishSignatureRequired = 'true' == rootProject.findProperty('publishSignatureRequired')
 def publishUrlForRelease = rootProject.findProperty('publishUrlForRelease')
 def publishUrlForSnapshot = rootProject.findProperty('publishUrlForSnapshot')
 def publishUsernameProperty = rootProject.findProperty('publishUsernameProperty')
 def publishPasswordProperty = rootProject.findProperty('publishPasswordProperty')
+def isReleasing = {
+    isReleaseVersion &&
+    'true' != System.getenv('JITPACK') &&
+    rootProject.ext.isPublishing()
+}
 
 if (publishSignatureRequired) {
     apply plugin: 'signing'
@@ -11,10 +16,11 @@ if (publishSignatureRequired) {
 
 rootProject.ext {
     isPublishing = { gradle.taskGraph.allTasks.find { it.name =~ /(?:^|:)publish[^:]*ToMaven[^:]*$/ } != null }
+
     if (publishSignatureRequired) {
         isSigning = {
             rootProject.signing.signatory != null &&
-            (isReleaseVersion || rootProject.hasProperty('sign'))
+            (isReleasing() || rootProject.hasProperty('sign'))
         }
     } else {
         isSigning = { false }
@@ -23,10 +29,7 @@ rootProject.ext {
     if (publishSignatureRequired) {
         gradle.taskGraph.whenReady {
             // Do *NOT* proceed if a user is publishing a release version and signatory is missing.
-            if (rootProject.ext.isPublishing() &&
-                isReleaseVersion &&
-                rootProject.signing.signatory == null) {
-
+            if (isReleasing() && rootProject.signing.signatory == null) {
                 throw new IllegalStateException(
                         'Cannot publish a release version without a GPG key; missing signatory')
             }


### PR DESCRIPTION
Motivation:

- https://github.com/line/armeria/issues/1732

Modifications:

- Do not enforce PGP signing even if we are building a release version
  only if the current build is running on JitPack.

Result:

- Can build a release version without a PGP signatory when on JitPack.