### PR TITLE
Fix the regression caused by JitPack workaround

### DIFF
--- a/lib/common-publish.gradle
+++ b/lib/common-publish.gradle
@@ -1,14 +1,11 @@
 def isReleaseVersion = !(rootProject.version.endsWith('-SNAPSHOT'))
-def publishSignatureRequired = 'true' == rootProject.findProperty('publishSignatureRequired')
+def publishSignatureRequired = 'true' == rootProject.findProperty('publishSignatureRequired') &&
+                               'true' != System.getenv('JITPACK') &&
+                               !rootProject.hasProperty('nosign')
 def publishUrlForRelease = rootProject.findProperty('publishUrlForRelease')
 def publishUrlForSnapshot = rootProject.findProperty('publishUrlForSnapshot')
 def publishUsernameProperty = rootProject.findProperty('publishUsernameProperty')
 def publishPasswordProperty = rootProject.findProperty('publishPasswordProperty')
-def isReleasing = {
-    isReleaseVersion &&
-    'true' != System.getenv('JITPACK') &&
-    rootProject.ext.isPublishing()
-}
 
 if (publishSignatureRequired) {
     apply plugin: 'signing'
@@ -16,11 +13,10 @@ if (publishSignatureRequired) {
 
 rootProject.ext {
     isPublishing = { gradle.taskGraph.allTasks.find { it.name =~ /(?:^|:)publish[^:]*ToMaven[^:]*$/ } != null }
-
     if (publishSignatureRequired) {
         isSigning = {
             rootProject.signing.signatory != null &&
-            (isReleasing() || rootProject.hasProperty('sign'))
+            (isReleaseVersion || rootProject.hasProperty('sign'))
         }
     } else {
         isSigning = { false }
@@ -29,9 +25,13 @@ rootProject.ext {
     if (publishSignatureRequired) {
         gradle.taskGraph.whenReady {
             // Do *NOT* proceed if a user is publishing a release version and signatory is missing.
-            if (isReleasing() && rootProject.signing.signatory == null) {
+            if (rootProject.ext.isPublishing() &&
+                isReleaseVersion &&
+                rootProject.signing.signatory == null) {
+
                 throw new IllegalStateException(
-                        'Cannot publish a release version without a GPG key; missing signatory')
+                        'Cannot publish a release version without a GPG key; missing signatory. ' +
+                        'Use "-Pnosign" option to disable PGP signing.')
             }
         }
     }


### PR DESCRIPTION
Motivation:

6e84338fefd22263629cdc453a278ad4326173ac introduces a bug where the
build script tries to access the task graph before it is ready during
the release, causing a build error.

Modifications:

- Revert 6e84338fefd22263629cdc453a278ad4326173ac and apply a simpler fix.
- Add `-Pnosign` option that disables PGP signing completely.

Result:

No more build errors during the release process