### PR TITLE
Make sure the `checkstyle` task depends on all Checkstyle tasks

### DIFF
--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -103,9 +103,14 @@ configure(projectsWithFlags('java')) {
             }
         }
 
-        task checkstyle(group: 'Verification',
-                description: 'Runs the checkstyle rules.',
-                dependsOn: [tasks.checkstyleMain, tasks.checkstyleTest])
+        task checkstyle(group: 'Verification', description: 'Runs the checkstyle rules.') {
+            project.sourceSets.all { SourceSet sourceSet ->
+                def dependencyTask = project.tasks.findByName(sourceSet.getTaskName("checkstyle", ""))
+                if (dependencyTask instanceof Checkstyle) {
+                    dependsOn dependencyTask
+                }
+            }
+        }
 
         test {
             dependsOn tasks.checkstyle


### PR DESCRIPTION
Motivation:

The `checkstyle` task currently only depends on `checkstyleMain` and
`checkstyleTest`, which does not cover other source sets.

Modifications:

- Make the `checkstyle` task depend on all `checkstyle*` tasks

Result:

- `./gradlew checkstyle` runs Checkstyle for all source sets.