### PR TITLE
Fix hasSourceDirectory to search for directory in breadth-first search

### DIFF
--- a/lib/common-misc.gradle
+++ b/lib/common-misc.gradle
@@ -5,11 +5,15 @@ allprojects {
 }
 
 static boolean hasSourceDirectory(Project project, String name) {
-    def queue = [] as Queue<File>
-    queue.add(new File(project.projectDir, 'src'))
+    def queue = [] as Queue
+    queue.add([
+            dir: new File(project.projectDir, 'src'),
+            depth: 0,
+    ])
     while (queue.size() > 0) {
-        def dir = queue.poll()
-        def children = dir.listFiles(new FileFilter() {
+        def e = queue.poll()
+
+        def children = e.dir.listFiles(new FileFilter() {
             @Override
             boolean accept(File pathname) {
                 return pathname.isDirectory()
@@ -19,7 +23,12 @@ static boolean hasSourceDirectory(Project project, String name) {
             if (child.getName() == name) {
                 return true
             }
-            queue.add(child)
+            if (e.depth < 3) {
+                queue.add([
+                        dir  : child,
+                        depth: e.depth + 1,
+                ])
+            }
         }
     }
     return false

--- a/lib/common-misc.gradle
+++ b/lib/common-misc.gradle
@@ -16,7 +16,7 @@ static boolean hasSourceDirectory(Project project, String name) {
             }
         })
         for (child in children) {
-            if (child.getName() == "proto") {
+            if (child.getName() == name) {
                 return true
             }
             queue.add(child)

--- a/lib/common-misc.gradle
+++ b/lib/common-misc.gradle
@@ -5,12 +5,22 @@ allprojects {
 }
 
 static boolean hasSourceDirectory(Project project, String name) {
-    return new File(project.projectDir, 'src').listFiles(new FileFilter() {
-        @Override
-        boolean accept(File pathname) {
-            return pathname.isDirectory()
+    def queue = [] as Queue<File>
+    queue.add(new File(project.projectDir, 'src'))
+    while (queue.size() > 0) {
+        def dir = queue.poll()
+        def children = dir.listFiles(new FileFilter() {
+            @Override
+            boolean accept(File pathname) {
+                return pathname.isDirectory()
+            }
+        })
+        for (child in children) {
+            if (child.getName() == "proto") {
+                return true
+            }
+            queue.add(child)
         }
-    }).find {
-        dir -> new File(dir, name).isDirectory()
-    } != null
+    }
+    return false
 }


### PR DESCRIPTION
In previous implementation, only the following directory structure was allowed.

```
src
|- main
    |- java
    |- proto
```

I think it should support in the following cases.

```
src
|- main
    |- java
    |- idl
        |- proto
```