### PR TITLE
Use JUnit platform when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ When a project has a `java` flag:
   - Publishing to a Maven repository
 
 - Full exception logging is enabled for tests.
+- JUnit platform is enabled for tests if the project depends on `junit-jupiter-engine`.
 - Checkstyle validation is enabled using `checkstyle` plugin if Checkstyle
   configuration file exists at `<project_root>/settings/checkstyle/checkstyle.xml`
 

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -88,7 +88,14 @@ configure(projectsWithFlags('java')) {
 
     // Enable full exception logging for test failures.
     tasks.withType(Test) {
-        it.testLogging.exceptionFormat = 'full'
+        testLogging.exceptionFormat = 'full'
+    }
+
+    // Use JUnit 5 if it's defined in the dependencies.
+    if (managedVersions.containsKey('org.junit.jupiter:junit-jupiter-engine')) {
+        tasks.withType(Test) {
+            useJUnitPlatform()
+        }
     }
 
     // Enforce checkstyle rules.


### PR DESCRIPTION
.. so that a user doesn't have to call `useJUnitPlatform()` for all
`Test` tasks.