### PR TITLE
Refer a cross-project task as a path rather than as a reference

### DIFF
--- a/lib/java-coverage.gradle
+++ b/lib/java-coverage.gradle
@@ -54,11 +54,11 @@ configure(rootProject) {
             // Set dependencies related with report generation and feed execution data.
             projects.each { Project p ->
                 if (p.hasFlags('relocate')) {
-                    reportTask.dependsOn(p.tasks.shadedClasses)
+                    reportTask.dependsOn(p.tasks.shadedClasses.path)
                 }
 
                 p.tasks.withType(Test).each { testTask ->
-                    reportTask.dependsOn(testTask)
+                    reportTask.dependsOn(testTask.path)
                     reportTask.mustRunAfter(testTask)
                     testTask.finalizedBy(reportTask)
 

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -91,8 +91,8 @@ configure(relocatedProjects) {
                 description: 'Shrinks the shaded JAR by removing unused classes.') {
 
             relocatedProjects.each {
-                dependsOn it.tasks.shadedJar
-                dependsOn it.tasks.shadedTestJar
+                dependsOn it.tasks.shadedJar.path
+                dependsOn it.tasks.shadedTestJar.path
             }
 
             def shadedFile = tasks.shadedJar.archivePath
@@ -172,9 +172,9 @@ configure(relocatedProjects) {
 
         relocatedProjects.each {
             if (it.tasks.findByName('trimShadedJar')) {
-                dependsOn it.tasks.trimShadedJar
+                dependsOn it.tasks.trimShadedJar.path
             } else {
-                dependsOn it.tasks.shadedJar
+                dependsOn it.tasks.shadedJar.path
             }
         }
         dependsOn tasks.shadedTestClasses


### PR DESCRIPTION
Motivation:

When configure-on-demand is enabled, inter-project dependencies are
calculated correctly only when task dependency is specified as a task
path string or Project.evaluationDependsOn() must be used. See:

- https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:configuration_on_demand

> The task dependencies declared via task path are supported and cause
> relevant projects to be configured.
> Example: someTask.dependsOn(":someOtherProject:someOtherTask")

Modifications:

- Use `Task.path` when referring to a task in a different project to
  call `Task.dependsOn()`
  - Note that `evaluationDependsOn()` does not work in our case because
    it can cause the projects to be evaluated too early.

Result:

- Fixes a bug where a certain project is not configured when it has to
  be, causing a weird compilation error due to unconfigured dependencies.
