### PR TITLE
Fix the 404 error caused by a bug in Javadoc `search.js`

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -28,6 +28,11 @@ allprojects {
                 l.rel = "noopener";
               }
             }
+            // Fix the 404 errors caused by getURLPrefix() returning undefined in search.js.
+            // See: https://stackoverflow.com/a/57284322/55808
+            if (typeof useModuleDirectories !== 'undefined') {
+              useModuleDirectories = false;
+            }
             </script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/gradle.min.js"></script>


### PR DESCRIPTION
Each `.html` file generated by Javadoc contains the following variable
definition:

    var useModuleDirectories = true;

Which affects the behavior of the `getURLPrefix()` function in
`search.js`:

    function getURLPrefix(ui) {
        var urlPrefix="";
        if (useModuleDirectories) {
            ...
        }
        return urlPrefix;
    }

Therefore, we can work around this issue by overriding the value of
`useModuleDirectories` with `false`.

See https://stackoverflow.com/a/57284322/55808 for more information.