### PR TITLE
Fix checkstyle dependency and run it sooner.

### DIFF
--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -110,11 +110,15 @@ configure(projectsWithFlags('java')) {
             }
         }
 
-        task checkstyle(group: 'Verification', description: 'Runs the checkstyle rules.') {
-            project.sourceSets.all { SourceSet sourceSet ->
-                def dependencyTask = project.tasks.findByName(sourceSet.getTaskName("checkstyle", ""))
-                if (dependencyTask instanceof Checkstyle) {
-                    dependsOn dependencyTask
+        task checkstyle(group: 'Verification', description: 'Runs the checkstyle rules.') {}
+        project.sourceSets.all { SourceSet sourceSet ->
+            def dependencyTask = project.tasks.findByName("checkstyle${sourceSet.name.capitalize()}")
+            if (dependencyTask instanceof Checkstyle) {
+                tasks.checkstyle.dependsOn dependencyTask
+
+                // Run checkstyle as soon as possible after compilation to get feedback earlier.
+                tasks.named(sourceSet.compileJavaTaskName).configure {
+                    finalizedBy dependencyTask
                 }
             }
         }


### PR DESCRIPTION
`getTaskName` returns `checkstyle` for the `main` source set, but the checkstyle task is `checkstyleMain`. So the dependency from `checkstyle` to `checkstyleMain` isn't being made (`checkstyleMain` still runs in the build because the checkstyle plugin adds the dependency on it from `check`).

Also made it so checkstyle runs just after compiling to get feedback earlier.

These changes make it so instead of `:core:checkstyleMain` being one of the last things run after 30 min on Travis to one of the first as it probably should be.