### PR TITLE
Add `lint` and `generateSources` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,25 +139,25 @@ com.google.guava:
   guava:
     version: '23.6-jre'
     exclusions:
-    - com.google.code.findbugs:jsr305
-    - com.google.errorprone:error_prone_annotations
-    - com.google.j2objc:j2objc-annotations
-    - org.codehaus.mojo:animal-sniffer-annotations
+      - com.google.code.findbugs:jsr305
+      - com.google.errorprone:error_prone_annotations
+      - com.google.j2objc:j2objc-annotations
+      - org.codehaus.mojo:animal-sniffer-annotations
 
 # More than one artifact under the same group:
 com.fasterxml.jackson.core:
   jackson-annotations:
     version: &JACKSON_VERSION '2.9.2' # Using a YAML anchor
     javadocs:
-    - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
+      - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
   jackson-core:
     version: *JACKSON_VERSION
     javadocs:
-    - https://fasterxml.github.io/jackson-core/javadoc/2.9/
+      - https://fasterxml.github.io/jackson-core/javadoc/2.9/
   jackson-databind:
     version: *JACKSON_VERSION
     javadocs:
-    - https://fasterxml.github.io/jackson-databind/javadoc/2.9/
+      - https://fasterxml.github.io/jackson-databind/javadoc/2.9/
 ```
 
 `dependencies.yml` will be parsed at project evaluation time and be fed into
@@ -249,7 +249,7 @@ All projects will get the following extension properties:
 - `executeGit(...args)` - executes a Git command with the specified arguments
 - `hasSourceDirectory(name)` - tells if the project has any source directory that matches `<projectDir>/src/*/<name>`, e.g.
 
-  ```java
+  ```groovy
   if (project.ext.hasSourceDirectory('thrift')) {
       println "${project} contains Thrift source files."
   }
@@ -337,6 +337,9 @@ When a project has a `java` flag:
 - Checkstyle validation is enabled using `checkstyle` plugin if Checkstyle
   configuration file exists at `<project_root>/settings/checkstyle/checkstyle.xml`
 
+  - A new task called `lint` is added to all projects with Checkstyle enabled.
+    - Consider adding dependency tasks to the `lint` task to do other jobs
+      such as static analysis.
   - A special configuration property `checkstyleConfigDir` is set so you can
     access the external files such as `suppressions.xml` from `checkstyle.xml`.
   - You can choose Checkstyle version by specifying it in `dependencies.yml`:
@@ -344,7 +347,7 @@ When a project has a `java` flag:
     com.puppycrawl.tools:
       checkstyle: { version: '8.5' }
     ```
-  - Checkstyle can be disabled completely by specifying `-PnoCheckstyle` option.
+  - Checkstyle can be disabled completely by specifying `-PnoLint` option.
 
 - Test coverage report is enabled using `jacoco` plugin if `-Pcoverage` option
   is specified.
@@ -356,8 +359,8 @@ When a project has a `java` flag:
     rootProject {
         ext {
             jacocoExclusions = [
-                '/com/example/generated/sources/**',
-                '/com/example/third/party/**'
+                    '/com/example/generated/sources/**',
+                    '/com/example/third/party/**'
             ]
         }
     }
@@ -381,8 +384,8 @@ When a project has a `java` flag:
     grpc-core:
       version: &GRPC_VERSION '1.8.0'
       javadocs:
-      - https://grpc.io/grpc-java/javadoc/
-      - https://developers.google.com/protocol-buffers/docs/reference/java/
+        - https://grpc.io/grpc-java/javadoc/
+        - https://developers.google.com/protocol-buffers/docs/reference/java/
   ```
 
   If you are in an environment with restricted network access, you can specify
@@ -391,6 +394,10 @@ When a project has a `java` flag:
 - The `.proto` files under `src/*/proto` will be compiled into Java code with
   [protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin).
 
+  - A new task called `generateSources` is added to all projects with `.proto`
+    files.
+    - Consider adding dependency tasks to the `generateSources` task to do
+      other source generation jobs.
   - You need to add `com.google.protobuf:protobuf-gradle-plugin` to
     `dependencies.yml` to get this to work.
   - Add `com.google.protobuf:protoc` to `dependencies.yml` to specify the
@@ -399,6 +406,10 @@ When a project has a `java` flag:
 
 - The `.thrift` files under `src/*/thrift` will be compiled into Java code.
 
+  - A new task called `generateSources` is added to all projects with `.thrift`
+    files.
+    - Consider adding dependency tasks to the `generateSources` task to do
+      other source generation jobs.
   - Thrift compiler 0.12 will be used by default. Override `thriftVersion`
     property if you prefer 0.9:
 

--- a/lib/common-misc.gradle
+++ b/lib/common-misc.gradle
@@ -1,6 +1,8 @@
 allprojects {
     ext {
         hasSourceDirectory = this.&hasSourceDirectory.curry(project)
+        getGenerateSourcesTask = this.&getGenerateSourcesTask.curry(project)
+        getLintTask = this.&getLintTask.curry(project)
     }
 }
 
@@ -13,4 +15,28 @@ static boolean hasSourceDirectory(Project project, String name) {
     }).find {
         dir -> new File(dir, name).isDirectory()
     } != null
+}
+
+static Task getGenerateSourcesTask(Project project) {
+    Task task = project.tasks.findByName('generateSources')
+    if (task == null) {
+        task = project.task([
+                group: 'Build', description: 'Generates required source files.'
+        ], 'generateSources');
+    }
+    return task
+}
+
+static Task getLintTask(Project project) {
+    Task task = project.tasks.findByName('lint')
+    if (task == null) {
+        task = project.task([
+                group: 'Verification', description: 'Runs all linting tools.'
+        ], 'lint')
+
+        if (project.tasks.findByName('check') != null) {
+            project.tasks.check.dependsOn(task)
+        }
+    }
+    return task
 }

--- a/lib/java-rpc-proto.gradle
+++ b/lib/java-rpc-proto.gradle
@@ -77,10 +77,12 @@ configure(projectsWithFlags('java')) {
         // Make sure protoc runs before the resources are copied so that .dsc files are included.
         project.afterEvaluate {
             project.sourceSets.each { sourceSet ->
+                def task = tasks.findByName(sourceSet.getTaskName('generate', 'proto'))
                 def processResourcesTask = tasks.findByName(sourceSet.getTaskName('process', 'resources'))
                 if (processResourcesTask != null) {
-                    processResourcesTask.dependsOn(tasks.findByName(sourceSet.getTaskName('generate', 'proto')))
+                    processResourcesTask.dependsOn(task)
                 }
+                project.ext.getGenerateSourcesTask().dependsOn(task)
             }
         }
     }

--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -99,6 +99,8 @@ configure(projectsWithFlags('java')) {
             if (compileTask != null) {
                 compileTask.dependsOn(task)
             }
+
+            project.ext.getGenerateSourcesTask().dependsOn(task)
         }
     }
 }

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -1,8 +1,9 @@
 // Enable checkstyle if the rule file exists.
 def checkstyleConfigDir = "${rootProject.projectDir}/settings/checkstyle"
 def checkstyleEnabled = !rootProject.hasProperty('noCheckstyle') &&
-                        new File(checkstyleConfigDir).isDirectory() &&
-                        new File("${checkstyleConfigDir}/checkstyle.xml").isFile()
+        !rootProject.hasProperty('noLint') &&
+        new File(checkstyleConfigDir).isDirectory() &&
+        new File("${checkstyleConfigDir}/checkstyle.xml").isFile()
 
 configure(rootProject) {
     apply plugin: 'eclipse'
@@ -100,8 +101,10 @@ configure(projectsWithFlags('java')) {
             }
         }
 
+        project.ext.getLintTask().dependsOn tasks.checkstyle
+
         test {
-            dependsOn tasks.checkstyle
+            dependsOn tasks.lint
         }
     }
 }


### PR DESCRIPTION
Motivation:

`checkstyle` is a tool-specific task name. There has to be a generic
task name for running all linting tools, so that a user can easily
run all the necessary linting tasks for the entire codebase.

There's no dedicated task for populating the generated source files. A
user had to rely on the tasks such as `checkstyle` so far.

Modifications:

- Added the `lint` task which is supposed to run all linting tasks,
  including `checkstyle`.
- Added the `generateSources` task which is supposed to run all
  source-generating tasks, including `compile*Thrift` and `generate*Proto`.
- Deprecated `noCheckstyle` property in favor of `noLint`.

Result:

- The new `lint` and `generateSources` tasks allow a user to add other
  linters/generators than Checkstyle/Protobuf/Thrift into the build
  process easily.
- We now can tell a user to run `generateSources` task before importing
  a project into an IDE.