### PR TITLE
Do not auto-disable incremental Java compilation

### DIFF
--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -46,7 +46,6 @@ configure(projectsWithFlags('java')) {
 
     // Set the sensible compiler options.
     tasks.withType(JavaCompile) {
-        def task = delegate
         sourceCompatibility = project.findProperty('javaSourceCompatibility') ?: '1.8'
         targetCompatibility = project.findProperty('javaTargetCompatibility') ?: '1.8'
         options.encoding = 'UTF-8'

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -52,18 +52,6 @@ configure(projectsWithFlags('java')) {
         options.encoding = 'UTF-8'
         options.warnings = false
         options.compilerArgs += '-parameters'
-        project.configurations.each { Configuration cfg ->
-            if (cfg.name == 'annotationProcessor' || cfg.name.endsWith('AnnotationProcessor')) {
-                cfg.withDependencies { deps ->
-                    // Use incremental compilation only when there are no annotation processors,
-                    // because it seems to cause compilation errors for some processors such as Lombok.
-                    def useIncrementalCompilation = deps.size() == 0
-                    options.incremental = useIncrementalCompilation
-                    logger.info("${useIncrementalCompilation ? 'Enabling' : 'Disabling'} " +
-                            "incremental compilation for '${task.path}'")
-                }
-            }
-        }
     }
 
     // Enable full exception logging for test failures.


### PR DESCRIPTION
Motivation:

The issues with incremental compilation is fairly old and it should now be generally safe to enable it back.
If there's still an issue with incremental compilation when used with a certain annotation processors, it can be force-disabled:

```
tasks.withType(JavaCompile) {
    optiona.incremental = false
}
```