### PR TITLE
Do not always run Checkstyle after compilation

### DIFF
--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -93,18 +93,11 @@ configure(projectsWithFlags('java')) {
             def dependencyTask = project.tasks.findByName("checkstyle${sourceSet.name.capitalize()}")
             if (dependencyTask instanceof Checkstyle) {
                 tasks.checkstyle.dependsOn dependencyTask
-
-                // Run checkstyle as soon as possible after compilation to get feedback earlier.
-                tasks.named(sourceSet.compileJavaTaskName).configure {
-                    finalizedBy dependencyTask
-                }
             }
         }
 
-        project.ext.getLintTask().dependsOn tasks.checkstyle
-
-        test {
-            dependsOn tasks.lint
-        }
+        def lintTask = project.ext.getLintTask()
+        lintTask.dependsOn tasks.checkstyle
+        tasks.check.dependsOn lintTask
     }
 }


### PR DESCRIPTION
It seriously increases our dev loop overhead when launching tests from IntelliJ.