### PR TITLE
feat: add enable full camel support

### DIFF
--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -2,9 +2,12 @@ def libDir = "${buildscript.sourceFile.parentFile}"
 
 configure(projectsWithFlags('java')) {
     def thriftJsonEnabled = true
+    def fullCamel = false
+
     ext {
         thriftVersion = null
         thriftPath = null
+        enableThriftFullCamel = { fullCamel = true }
         disableThriftJson = { thriftJsonEnabled = false }
     }
 
@@ -35,7 +38,7 @@ configure(projectsWithFlags('java')) {
                 srcDirs = [srcDirs]
             }
 
-            def includeDirs = project.findProperty(sourceSet.getTaskName('', 'thriftIncludeDirs'))?: []
+            def includeDirs = project.findProperty(sourceSet.getTaskName('', 'thriftIncludeDirs')) ?: []
             if (!(includeDirs instanceof Iterable) || includeDirs instanceof CharSequence) {
                 includeDirs = [includeDirs]
             }
@@ -64,9 +67,13 @@ configure(projectsWithFlags('java')) {
                         }.each { sourceFile ->
                             logger.info("Using ${actualThriftPath} to generate Java sources from ${sourceFile}")
                             project.mkdir(javaOutputDir)
+                            def javaGenerator = 'java'
+                            if (fullCamel) {
+                                javaGenerator = 'java:fullcamel'
+                            }
                             project.exec {
                                 commandLine actualThriftPath
-                                args '-gen', 'java', '-out', javaOutputDir
+                                args '-gen', javaGenerator, '-out', javaOutputDir
                                 includeDirs.each {
                                     args '-I', it
                                 }


### PR DESCRIPTION
Motivation:

User might use underscored style thrift method name, but want it convert to camel in java. 
This is supported by thrift compiler's option `fullcamel`

Modification:

Add `enableThriftFullCamel` to support thrift compiler options `fullcamel`.


Usage:

```groovy
ext {
   enableThriftFullCamel()
}
```
