### PR TITLE
More strict managed dependency lookup

### DIFF
--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -22,7 +22,17 @@ rootProject.ext {
     }
 }
 
-def managedDependencyVersions = [:]
+def managedDependencyVersions = new TreeMap<String, String>() {
+    @Override
+    String get(Object key) {
+        def value = super.get(key)
+        if (value != null) {
+            return value
+        } else {
+            throw new IllegalArgumentException("Missing managed dependency: ${key}")
+        }
+    }
+}
 def managedDependencyExclusions = [:].withDefault { [] }
 def managedDependencyOverrides = [] as Set
 rootProject.ext.dependenciesYaml.forEach { String key, value ->
@@ -216,12 +226,10 @@ rootProject.ext {
             def groupId = entry.key
             entry.value.forEach { String artifactId, Map props ->
                 if (props.containsKey('javadocs')) {
-                    def version = String.valueOf(managedDependencyVersions["${groupId}:${artifactId}"])
                     props['javadocs'].each { url ->
                         list.add([
                                 groupId: groupId,
                                 artifactId: artifactId,
-                                version: version,
                                 url: url
                         ])
                     }
@@ -244,9 +252,12 @@ configure(rootProject) {
     task managedVersions(
             group: 'Build',
             description: 'Generates the file that contains dependency versions.') {
+
+        def f = file("${project.buildDir}/managed_versions.yml")
         inputs.properties managedDependencyVersions
+        outputs.file(f)
+
         doLast {
-            def f = file("${project.buildDir}/managed_versions.yml")
             f.parentFile.mkdir()
             f.withWriter('UTF-8') {
                 new Yaml().dump(managedDependencyVersions, it)

--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -299,7 +299,7 @@ allprojects {
             }
 
             project.ext.javadocLinks.each {
-                addOfflineLink("${it['groupId']}/${it['artifactId']}/${it['version']}", it['url'])
+                addOfflineLink("${it['groupId']}/${it['artifactId']}", it['url'])
             }
         }
     }


### PR DESCRIPTION
Motivation:

It is currently hard to know whether a user made a mistake or not when a
user specified an incorrect dependency ID when accessing the
`managedVersions` map.

Modifications:

- Raise an exception explicitly when there's no mapping for a given
  dependency ID, so that a user knows the problem earlier.
- Remove the `version` property from `javadocLinks` because it's not
  always available.

Result:

- Less error-prone