### PR TITLE
Hide the 'dependencyManagement' project directory

### DIFF
--- a/settings-flags.gradle
+++ b/settings-flags.gradle
@@ -151,3 +151,4 @@ static void afterProjectsWithFlags(Project project, Iterable<?> flags, Closure<S
 // We add a "virtual project", with no source code, to control dependency management using Gradle's platform
 // functionality.
 includeWithFlags ':dependencyManagement', 'dependencyManagement'
+project(':dependencyManagement').projectDir = file("${rootProject.projectDir}/build/dependencyManagement")


### PR DESCRIPTION
Motivation:

When a user runs `gradle dependencyUpdates`, Gradle will create a
directory `dependencyManagement` automatically. This directory could be
hidden under the root project's `build` directory because it will only
contain a dependency update report.

Modification:

- Change the project directory of `dependencyManagement` project to
  `rootProject.projectDir/build/dependencyManagement`.

Result:

- Less annoyance