### PR TITLE
Wait for process output when executing commands

### DIFF
--- a/lib/common-git.gradle
+++ b/lib/common-git.gradle
@@ -96,12 +96,15 @@ private static String executeCommand(...command) {
     command.each { cmd += it.toString() }
 
     def proc = cmd.execute()
-    proc.waitFor()
+    def stdout = new StringWriter()
+    def stderr = new StringWriter()
+    proc.waitForProcessOutput(stdout, stderr)
+
     if (proc.exitValue() != 0) {
         throw new IOException(
                 "'${command}' exited with a non-zero exit code: ${proc.exitValue()}:" +
-                        "${System.lineSeparator()}${proc.err.text}")
+                        "${System.lineSeparator()}${stderr.toString().trim()}")
     }
 
-    return proc.in.text.trim()
+    return stdout.toString().trim()
 }


### PR DESCRIPTION
#### Motivation
When using `Process.waitFor()` and executing a command with a lot of output (for example `git tag -l "foo*"`), the stream buffers can fill up, causing the program to hang, waiting for user to read the streams. This seems to depend on OS implementation, which made it difficult to replicate.

Using `Process.waitForProcessOutput()` fixes this issue since it consumes stdout and stderr in separate threads before waiting for the process to exit.

#### Modifications
- Use `Process.waitForProcessOutput()` instead of `Process.waitFor()`
- Trim final newline in error message

#### Result
Commands with a lot of output do not hang anymore.