### PR TITLE
Use first git.exe if multiple `git.exe`s are installed

### DIFF
--- a/lib/common-git.gradle
+++ b/lib/common-git.gradle
@@ -29,11 +29,7 @@ private def getGitPath() {
         if (current() == WINDOWS) {
             def commands = executeCommand('where.exe', 'git.exe')
             // "where.exe" returns all available commands, so select the first git.exe.
-            def index = commands.indexOf("git.exe")
-            if (index < 0) {
-                throw new IllegalStateException("Failed to find git.exe")
-            }
-            return commands.substring(0, index + "git.exe".length())
+            return commands.split('\r\n')[0]
         } else {
             return executeCommand('which', 'git')
         }

--- a/lib/common-git.gradle
+++ b/lib/common-git.gradle
@@ -27,7 +27,13 @@ private def getGitPath() {
     // Find the location of the 'git' command.
     try {
         if (current() == WINDOWS) {
-            return executeCommand('where.exe', 'git.exe')
+            def commands = executeCommand('where.exe', 'git.exe')
+            // "where.exe" returns all available commands, so select the first git.exe.
+            def index = commands.indexOf("git.exe")
+            if (index < 0) {
+                throw new IllegalStateException("Failed to find git.exe")
+            }
+            return commands.substring(0, index + "git.exe".length())
         } else {
             return executeCommand('which', 'git')
         }


### PR DESCRIPTION
Motivation:

If multiple `git.exe`s are installed on Windows,
`where.exe git.exe` will return all available `git.exe`s
When executing the returned result from the `where.exe`, I got the following exception.
```
Failed to retrieve the repository status:
java.io.IOException: Cannot run program "C:\Program Files\Git\bin\git.exe
C:\Program Files\Git\cmd\git.exe
C:\Program Files\Git\mingw64\bin\git.exe": CreateProcess error=2, The system cannot find the file specified
```

Modifications:

- Select the first `git.exe` from the `where.exe git.exe`

Result:

Better Windows support