### PR TITLE
Use Toolchains to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ sensible defaults. By applying them, you can:
 - [Using flags](#using-flags)
     - [Built-in flags](#built-in-flags)
 - [Building Java projects with `java` flag](#building-java-projects-with-java-flag)
+- [Overriding JDK version](#overriding-jdk-version)
 - [Publishing to Maven repository with `publish` flag](#publishing-to-maven-repository-with-publish-flag)
 - [Generating Maven BOM with `bom` flag](#generating-maven-bom-with-bom-flag)
 - [Building shaded JARs with `shade` flag](#building-shaded-jars-with-shade-flag)
@@ -137,7 +138,7 @@ com.google.code.findbugs:
 # Slightly more verbose, but useful when an artifact has more than one property:
 com.google.guava:
   guava:
-    version: '23.6-jre'
+    version: '30.1.1-jre'
     exclusions:
       - com.google.code.findbugs:jsr305
       - com.google.errorprone:error_prone_annotations
@@ -147,17 +148,17 @@ com.google.guava:
 # More than one artifact under the same group:
 com.fasterxml.jackson.core:
   jackson-annotations:
-    version: &JACKSON_VERSION '2.9.2' # Using a YAML anchor
+    version: &JACKSON_VERSION '2.12.2' # Using a YAML anchor
     javadocs:
-      - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
+      - https://fasterxml.github.io/jackson-annotations/javadoc/2.12/
   jackson-core:
     version: *JACKSON_VERSION
     javadocs:
-      - https://fasterxml.github.io/jackson-core/javadoc/2.9/
+      - https://fasterxml.github.io/jackson-core/javadoc/2.12/
   jackson-databind:
     version: *JACKSON_VERSION
     javadocs:
-      - https://fasterxml.github.io/jackson-databind/javadoc/2.9/
+      - https://fasterxml.github.io/jackson-databind/javadoc/2.12/
 ```
 
 `dependencies.yml` will be parsed at project evaluation time and be fed into
@@ -216,7 +217,7 @@ applied so you can conveniently check if your dependencies are out of date:
 $ ./gradlew dependencyUpdates
 ...
 The following dependencies have later integration versions:
- - com.google.guava:guava [17.0 -> 24.0-jre]
+ - com.google.guava:guava [17.0 -> 30.1.1-jre]
 ```
 
 ## Built-in properties and functions
@@ -372,7 +373,7 @@ When a project has a `java` flag:
 
   ```yaml
   org.mortbay.jetty.alpn:
-    jetty-alpn-agent: { version: '2.0.6' }
+    jetty-alpn-agent: { version: '2.0.10' }
   ```
 
 - The `package-list` files of the Javadocs specified in `dependencies.yml` will
@@ -382,7 +383,7 @@ When a project has a `java` flag:
   ```yaml
   io.grpc:
     grpc-core:
-      version: &GRPC_VERSION '1.8.0'
+      version: &GRPC_VERSION '1.36.1'
       javadocs:
         - https://grpc.io/grpc-java/javadoc/
         - https://developers.google.com/protocol-buffers/docs/reference/java/
@@ -410,7 +411,7 @@ When a project has a `java` flag:
     files.
     - Consider adding dependency tasks to the `generateSources` task to do
       other source generation jobs.
-  - Thrift compiler 0.12 will be used by default. Override `thriftVersion`
+  - Thrift compiler 0.14 will be used by default. Override `thriftVersion`
     property if you prefer 0.9:
 
     ```groovy
@@ -430,6 +431,22 @@ When a project has a `java` flag:
         testThriftIncludeDirs = ["$projectDir/src/test/bar-include"]
     }
     ```
+
+## Overriding JDK version
+
+The scripts use [Toolchains](https://docs.gradle.org/current/userguide/toolchains.html) to build a Java
+project. It uses [AdoptOpenJDK](https://adoptopenjdk.net/) 15 by default. If you want to use a
+different JDK version, you can specify `buildJdkVersion` gradle property:
+
+```
+$ ./gradlew build -PbuildJdkVersion=11
+```
+
+You can also specify a different JRE version to run the tests via `testJavaVersion` gradle property:
+
+```
+$ ./gradlew test -PbuildJdkVersion=15 -PtestJavaVersion=8
+```
 
 ## Publishing to Maven repository with `publish` flag
 

--- a/lib/java-alpn.gradle
+++ b/lib/java-alpn.gradle
@@ -1,5 +1,5 @@
-// JDK 9 does not require Jetty ALPN agent at all.
-if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && System.env.TEST_JAVA_VERSION != '8') {
+// JDK 9 or above does not require Jetty ALPN agent at all.
+if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && rootProject.findProperty('testJavaVersion') != '8') {
     return
 }
 

--- a/lib/java-rpc-thrift.gradle
+++ b/lib/java-rpc-thrift.gradle
@@ -57,7 +57,7 @@ configure(projectsWithFlags('java')) {
                     } else {
                         actualThriftPath =
                                 "${libDir}/thrift" +
-                                "/${project.findProperty('thriftVersion')?: '0.13'}" +
+                                "/${project.findProperty('thriftVersion')?: '0.14'}" +
                                 "/thrift.${rootProject.osdetector.classifier}"
                     }
 

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -10,7 +10,7 @@ if (rootProject.hasProperty('buildJdkVersion')) {
     def jdkVersion = rootProject.findProperty('buildJdkVersion')
     if (buildJdkVersion != jdkVersion) {
         buildJdkVersion = jdkVersion
-        logger.quiet("Overriding jDK for build with ${buildJdkVersion}")
+        logger.quiet("Overriding JDK for build with ${buildJdkVersion}")
     }
 }
 
@@ -19,7 +19,7 @@ if (rootProject.hasProperty('testJavaVersion')) {
     def testVersion = rootProject.findProperty('testJavaVersion')
     if (buildJdkVersion != testVersion) {
         testJavaVersion = testVersion
-        logger.quiet("Overriding JVM for tests with ${testJavaVersion}")
+        logger.quiet("Overriding JRE for tests with ${testJavaVersion}")
     }
 }
 

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -5,6 +5,24 @@ def checkstyleEnabled = !rootProject.hasProperty('noCheckstyle') &&
         new File(checkstyleConfigDir).isDirectory() &&
         new File("${checkstyleConfigDir}/checkstyle.xml").isFile()
 
+def buildJdkVersion = 15
+if (rootProject.hasProperty('buildJdkVersion')) {
+    def jdkVersion = rootProject.findProperty('buildJdkVersion')
+    if (buildJdkVersion != jdkVersion) {
+        buildJdkVersion = jdkVersion
+        logger.quiet("Overriding jDK for build with ${buildJdkVersion}")
+    }
+}
+
+def testJavaVersion
+if (rootProject.hasProperty('testJavaVersion')) {
+    def testVersion = rootProject.findProperty('testJavaVersion')
+    if (buildJdkVersion != testVersion) {
+        testJavaVersion = testVersion
+        logger.quiet("Overriding JVM for tests with ${testJavaVersion}")
+    }
+}
+
 configure(rootProject) {
     apply plugin: 'eclipse'
     apply plugin: 'idea'
@@ -24,6 +42,14 @@ configure(projectsWithFlags('java')) {
     }
     clean {
         delete project.ext.genSrcDir
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(buildJdkVersion)
+            vendor = JvmVendorSpec.ADOPTOPENJDK
+            implementation = JvmImplementation.VENDOR_SPECIFIC
+        }
     }
 
     // Add the generated source directories to the source sets.
@@ -54,13 +80,18 @@ configure(projectsWithFlags('java')) {
     }
 
     // Enable full exception logging for test failures.
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
         testLogging.exceptionFormat = 'full'
-    }
 
-    // Use JUnit platform.
-    tasks.withType(Test) {
+        // Use JUnit platform.
         useJUnitPlatform()
+
+        // Use a different JRE for testing if necessary.
+        if (testJavaVersion != null) {
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(testJavaVersion)
+            }
+        }
     }
 
     // Enforce checkstyle rules.


### PR DESCRIPTION
Related to https://github.com/line/armeria/pull/3467

Modifications:
- Use Toolchains
  - JDK 15 is used to build a Java project by default
  - You can specify `-PbuildJdkVersion` to override it.
    `./gradlew build -PbuildJdkVersion=15`
  - You can also specify `-PtestJavaVersion` to run the tests with a different JRE
    `./gradlew test -PbuildJdkVersion=14 -PtestJavaVersion=8`