### PR TITLE
Make the Javadoc slightly look better

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -73,11 +73,25 @@ allprojects {
 
             // Highlight.js
             scriptParts.add('''
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/languages/gradle.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/languages/protobuf.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/languages/thrift.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/languages/yaml.min.js"></script>
+            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/darcula.min.css">
+            <style>
+            .hljs-ln-numbers {
+              user-select: none;
+              text-align: right;
+              color: #777;
+              border-right: 1px solid #555;
+              vertical-align: top;
+              padding-right: 5px !important;
+            }
+            .hljs-ln-code {
+              padding-left: 10px !important;
+            }
+            </style>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/languages/gradle.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/languages/protobuf.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/languages/thrift.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/languages/yaml.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.8.0/highlightjs-line-numbers.min.js"></script>
             <script>
             // Trim and syntax-highlight the code snippets.
@@ -136,6 +150,136 @@ allprojects {
               }
             }
             </script>''')
+
+            // Make the content narrower when not printing for readability.
+            scriptParts.add('''
+            <style>
+            body > .flex-box > .flex-content > main {
+              width: 100%;
+              max-width: 1024px;
+              margin-left: auto;
+              margin-right: auto;
+            }
+            </style>
+            ''')
+
+
+            // Replace fonts:
+            // - DejaVu Sans -> Lato
+            // - DejaVu Serif -> Lato
+            // - DejaVu Sans Mono -> Hack
+            ['DejaVu Sans', 'DejaVu Serif'].each { fontName ->
+                scriptParts.add("""
+                <style>
+                /* latin (normal)*/
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: normal;
+                  font-weight: 400;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6uyw4BMUTPHjx4wXg.woff2) format('woff2');
+                  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                }
+                /* latin-ext (normal)*/
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: normal;
+                  font-weight: 400;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6uyw4BMUTPHjxAwXjeu.woff2) format('woff2');
+                  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+                }
+                /* latin (bold) */
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: normal;
+                  font-weight: 700;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6u9w4BMUTPHh6UVSwiPGQ.woff2) format('woff2');
+                  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                }
+                /* latin-ext (bold) */
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: normal;
+                  font-weight: 700;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6u9w4BMUTPHh6UVSwaPGR_p.woff2) format('woff2');
+                  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+                }
+                /* latin (italic) */
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: italic;
+                  font-weight: 400;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6u8w4BMUTPHjxsAXC-q.woff2) format('woff2');
+                  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                }
+                /* latin-ext (italic) */
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: italic;
+                  font-weight: 400;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6u8w4BMUTPHjxsAUi-qJCY.woff2) format('woff2');
+                  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+                }
+                /* latin (bold italic) */
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: italic;
+                  font-weight: 700;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6u_w4BMUTPHjxsI5wq_Gwft.woff2) format('woff2');
+                  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                }
+                /* latin-ext (bold italic) */
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: italic;
+                  font-weight: 700;
+                  font-display: swap;
+                  src: url(https://fonts.gstatic.com/s/lato/v17/S6u_w4BMUTPHjxsI5wq_FQft1dw.woff2) format('woff2');
+                  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+                }
+                </style>
+                """)
+            }
+            ['DejaVu Sans Mono'].each { fontName ->
+                scriptParts.add("""
+                <style>
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: normal;
+                  font-weight: 400;
+                  font-display: swap;
+                  src: url('fonts/hack-regular-subset.woff2?sha=3114f1256') format('woff2'), url('fonts/hack-regular-subset.woff?sha=3114f1256') format('woff');
+                }
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: normal;
+                  font-weight: 700;
+                  font-display: swap;
+                  src: url('fonts/hack-bold-subset.woff2?sha=3114f1256') format('woff2'), url('fonts/hack-bold-subset.woff?sha=3114f1256') format('woff');
+                }
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: italic;
+                  font-weight: 400;
+                  font-display: swap;
+                  src: url('fonts/hack-italic-subset.woff2?sha=3114f1256') format('woff2'), url('fonts/hack-italic-webfont.woff?sha=3114f1256') format('woff');
+                }
+                @font-face {
+                  font-family: '${fontName}';
+                  font-style: italic;
+                  font-weight: 700;
+                  font-display: swap;
+                  src: url('fonts/hack-bolditalic-subset.woff2?sha=3114f1256') format('woff2'), url('fonts/hack-bolditalic-subset.woff?sha=3114f1256') format('woff');
+                }
+                </style>
+                """)
+            }
 
             bottom = project.ext.copyrightFooter +
                      scriptParts.join('').readLines().stream()


### PR DESCRIPTION
- Updated Highlight.js to 10.7.2.
- Imported Highlight.js styles.
- Added highlihgjs-line-numbers.js styles.
- Made the main content narrower when reading on screen for readability.
- Replaced DejaVu fonts with Lato and Hack for consistency with our web
  site.
- Changed the syntax highlighting theme to 'Darcula'
