### PR TITLE
Use `'\r\n|\n'` to split `where.exe git.exe` result

### DIFF
--- a/lib/common-git.gradle
+++ b/lib/common-git.gradle
@@ -29,7 +29,7 @@ private def getGitPath() {
         if (current() == WINDOWS) {
             def commands = executeCommand('where.exe', 'git.exe')
             // "where.exe" returns all available commands, so select the first git.exe.
-            return commands.split('\r\n')[0]
+            return commands.split('\r\n|\n')[0]
         } else {
             return executeCommand('which', 'git')
         }


### PR DESCRIPTION
Motivation:

If we split a multi-line string with `\r\n`, we saw a multi-line in the returned array.
I guess the result could contain both `\r\n` and `\n` even though it is Windows system.

Modifications:

- Use `\n` or `\r\n` to split a multi-line string

Result:

No longer see an warn message whiling intializing Gradle scripts