### PR TITLE
Make `testJavaVersion` and `buildJdkVersion` as global variables

### DIFF
--- a/lib/java-alpn.gradle
+++ b/lib/java-alpn.gradle
@@ -1,5 +1,5 @@
 // JDK 9 or above does not require Jetty ALPN agent at all.
-if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && rootProject.findProperty('testJavaVersion') != '8') {
+if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && rootProject.ext.testJavaVersion != 8) {
     return
 }
 

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -1,27 +1,29 @@
+def buildJdkVersion = 15
+if (rootProject.hasProperty('buildJdkVersion')) {
+    def jdkVersion = Integer.parseInt(rootProject.findProperty('buildJdkVersion'))
+    if (buildJdkVersion != jdkVersion) {
+        buildJdkVersion = jdkVersion
+        logger.quiet("Overriding JDK for build with ${buildJdkVersion}")
+    }
+}
+rootProject.ext.set("buildJdkVersion", buildJdkVersion)
+
+def testJavaVersion = buildJdkVersion
+if (rootProject.hasProperty('testJavaVersion')) {
+    def testVersion = Integer.parseInt(rootProject.findProperty('testJavaVersion'))
+    if (buildJdkVersion != testVersion) {
+        testJavaVersion = testVersion
+        logger.quiet("Overriding JRE for tests with ${testJavaVersion}")
+    }
+}
+rootProject.ext.set("testJavaVersion", testJavaVersion)
+
 // Enable checkstyle if the rule file exists.
 def checkstyleConfigDir = "${rootProject.projectDir}/settings/checkstyle"
 def checkstyleEnabled = !rootProject.hasProperty('noCheckstyle') &&
         !rootProject.hasProperty('noLint') &&
         new File(checkstyleConfigDir).isDirectory() &&
         new File("${checkstyleConfigDir}/checkstyle.xml").isFile()
-
-def buildJdkVersion = 15
-if (rootProject.hasProperty('buildJdkVersion')) {
-    def jdkVersion = rootProject.findProperty('buildJdkVersion')
-    if (buildJdkVersion != jdkVersion) {
-        buildJdkVersion = jdkVersion
-        logger.quiet("Overriding JDK for build with ${buildJdkVersion}")
-    }
-}
-
-def testJavaVersion
-if (rootProject.hasProperty('testJavaVersion')) {
-    def testVersion = rootProject.findProperty('testJavaVersion')
-    if (buildJdkVersion != testVersion) {
-        testJavaVersion = testVersion
-        logger.quiet("Overriding JRE for tests with ${testJavaVersion}")
-    }
-}
 
 configure(rootProject) {
     apply plugin: 'eclipse'
@@ -46,7 +48,7 @@ configure(projectsWithFlags('java')) {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(buildJdkVersion)
+            languageVersion = JavaLanguageVersion.of(rootProject.ext.buildJdkVersion)
             vendor = JvmVendorSpec.ADOPTOPENJDK
             implementation = JvmImplementation.VENDOR_SPECIFIC
         }
@@ -93,9 +95,9 @@ configure(projectsWithFlags('java')) {
         useJUnitPlatform()
 
         // Use a different JRE for testing if necessary.
-        if (testJavaVersion != null) {
+        if (rootProject.ext.buildJdkVersion != rootProject.ext.testJavaVersion) {
             javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(testJavaVersion)
+                languageVersion = JavaLanguageVersion.of(rootProject.ext.testJavaVersion)
             }
         }
     }


### PR DESCRIPTION
so that a user does not have to parse the version by him/herslef.
Related https://github.com/line/armeria/pull/3663/