### PR TITLE
Force `koltin-reflect` version to align with other Kotlin libs.

### DIFF
--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -38,4 +38,15 @@ configure(projectsWithFlags('kotlin')) {
             project.ext.getLintTask().dependsOn(tasks.ktlintCheck)
         }
     }
+
+    // A workaround for runtime JAR files in the classpath should have the same version.
+    // See: https://stackoverflow.com/questions/42569445/warning-kotlin-runtime-jar-files-in-the-classpath-should-have-the-same-version
+    configurations.all {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            def requested = details.requested
+            if (requested.group == 'org.jetbrains.kotlin' && requested.name == 'kotlin-reflect') {
+                details.useVersion managedVersions['org.jetbrains.kotlin:kotlin-reflect']
+            }
+        }
+    }
 }


### PR DESCRIPTION
Recently, I saw the following error when building Armeria projects.
```
w: Runtime JAR files in the classpath should have the same version.
These files were found in the classpath:
    .../files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.10/3f4af7aff21c4ec46e3cdd645639d0a63a68d3d0/kotlin-stdlib-jdk8-1.5.10.jar (version 1.5)
    .../files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.10/c49d0703d16c6cb1526cc07b9b46486da1dd8a60/kotlin-stdlib-jdk7-1.5.10.jar (version 1.5)
    .../files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.21/748f681f4e3edbe9285ff46710c79049c70f4dfa/kotlin-reflect-1.4.21.jar (version 1.4)
    .../files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.10/da6a904b132f0402fa4d79169a3c1770598d4702/kotlin-stdlib-1.5.10.jar (version 1.5)
    .../files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.10/6b84d926e28493be69daf673e40076f89492ef7/kotlin-stdlib-common-1.5.10.jar (version 1.5)
  w: Consider providing an explicit dependency on kotlin-reflect 1.5 to
  prevent strange errors
  w: Some runtime JAR files in the classpath have an incompatible
  version. Consider removing them from the classpath
```
The warning is removed by aligning `kotlin-reflect` version with `kotlin-stblib`