### PR TITLE
Do not specify JDK vendor in toolchain settings

### DIFF
--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -49,7 +49,6 @@ configure(projectsWithFlags('java')) {
     java {
         toolchain {
             languageVersion = JavaLanguageVersion.of(rootProject.ext.buildJdkVersion)
-            vendor = JvmVendorSpec.ADOPTOPENJDK
             implementation = JvmImplementation.VENDOR_SPECIFIC
         }
     }


### PR DESCRIPTION
Motivation:

Gradle currently has a bug related with vendor detection:

- https://github.com/gradle/gradle/issues/18182

Modification:

- Stop specifying JDK vendor to work around the Gradle bug.
  - The differences between JDK vendors are minimal anyway.

Result:

Gradle does not download JDK over and over again.