### PR TITLE
Support sub flag for bom project

### DIFF
--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -21,7 +21,9 @@ configure(projectsWithFlags('bom')) {
                 }
                 return "${a.ext.artifactId}".compareTo("${b.ext.artifactId}")
             }.each { p ->
-                api "${p.group}:${p.ext.artifactId}:${p.version}"
+                if (!project.flags.contains('sub') || project.parent.subprojects.contains(p)) {
+                    api "${p.group}:${p.ext.artifactId}:${p.version}"
+                }
             }
         }
     }


### PR DESCRIPTION
I'd like to support 'sub' flag. It's for subproject which is bom when should add only under projects of a subproject.
```
// project tree
a-project
|- api
|- common
b-project
|- common
```

```
// settings.gradle
includeWithFlags :a-project:bom, 'bom'
includeWithFlags :a-project:api, 'java', 'publish'
includeWithFlags :a-project:common, 'java', 'publish'

includeWithFlags :b-project:common, 'java', 'publish'
```

When I create a-project bom, b-project's common project will be added to the pom file as a dependency. If use 'sub' flag, b-project's common won't be added to the pom file.