### PR TITLE
Add the `-Xskip-prerelease-check` option to Kotlin compiler

### DIFF
--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -3,7 +3,7 @@ configure(projectsWithFlags('kotlin')) {
     apply plugin: 'kotlin'
 
     def target = "1.8"
-    def compilerArgs = ["-Xjsr305=strict", "-java-parameters"]
+    def compilerArgs = ['-java-parameters', '-Xjsr305=strict', '-Xskip-prerelease-check']
     compileKotlin {
         kotlinOptions.jvmTarget = target
         kotlinOptions.freeCompilerArgs = compilerArgs


### PR DESCRIPTION
Motivation:

A user sometimes gets the 'Class X is compiled by a pre-release version
of Kotlin and cannot be loaded by this version of the compiler' error,
which is often harmless.

Modifications:

- Added the `-Xskip-prerelease-check` option to `compileKotlin` and
  `compileTestKotlin`.

Result:

- Probably less surprising Kotlin compiler behavior