### PR TITLE
Add `nexus publish plugin` as explicit pre-requisite & fix Kotlin script bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ sensible defaults. By applying them, you can:
    ```groovy
    plugins {
        id 'com.google.osdetector' version '1.6.2' apply false
+       id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
    }
 
    apply from: "${rootDir}/gradle/scripts/build-flags.gradle"

--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -44,7 +44,8 @@ configure(projectsWithFlags('kotlin')) {
     configurations.all {
         resolutionStrategy.eachDependency { DependencyResolveDetails details ->
             def requested = details.requested
-            if (requested.group == 'org.jetbrains.kotlin' && requested.name == 'kotlin-reflect') {
+            if (requested.group == 'org.jetbrains.kotlin' && requested.name == 'kotlin-reflect' &&
+                    managedVersions.containsKey('org.jetbrains.kotlin:kotlin-reflect')) {
                 details.useVersion managedVersions['org.jetbrains.kotlin:kotlin-reflect']
             }
         }

--- a/lib/prerequisite.gradle
+++ b/lib/prerequisite.gradle
@@ -1,10 +1,12 @@
 try {
     rootProject.apply plugin: 'com.google.osdetector'
+    rootProject.apply plugin: 'io.github.gradle-nexus.publish-plugin'
 } catch (UnknownPluginException e) {
     throw new IllegalStateException('''Add the following to the top-level build.gradle file:
 
 plugins {
     id 'com.google.osdetector' version '1.6.2' apply false
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
 }
 ''')
 }


### PR DESCRIPTION
#### Motivation:
* `io.github.gradle-nexus.publish-plugin` as implicit pre-requisite
  - `README` and error messages claims that `com.google.osdetector` is the sole pre-requisite but actually, the script won't work without adding `io.github.gradle-nexus.publish-plugin`, which effectively makes it another pre-requisite (but implicit).
  - Error message:
    ```
    * What went wrong:
    A problem occurred evaluating script.
    > Could not find method nexusPublishing() for arguments [common_publish_bgpspjl0ajioxgwmtr8i54eq6$_run_closure3@6eef5c67] on root project 'test-proj' of type org.gradle.api.Project.
    ```

* Kotlin sub-module build fails without specifying `kotlin-reflect` in `dependencies.yml`
  - This only happens if one of the kotlin sub-modules in the project depends on `kotlin-reflect`.