### PR TITLE
Introduce bomGroups property

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,10 +484,8 @@ generate Maven BOM based on the dependencies specified in `dependencies.yml`.
 `bom` flag implies `publish` flag, which means the BOM will be uploaded to a
 Maven repository by `./gradlew publish`.
 
-If you want to specify a subprojects, you can add `bomGroups` property. When generate
-Maven BOM of the project, The specific subprojects will be added into this bom file as dependency.
-If you exclude a project from the `bomGroups` property, the generated bom file of that project will
-have subprojects as if you didn't use the `bomGroups` property.
+If you want to publish multiple boms with different subprojects, you can use the `bomGroups` extension property.
+Specify each bom's name with the subprojects:
 ```groovy
 ext {
     bomGroups = [

--- a/README.md
+++ b/README.md
@@ -484,6 +484,17 @@ generate Maven BOM based on the dependencies specified in `dependencies.yml`.
 `bom` flag implies `publish` flag, which means the BOM will be uploaded to a
 Maven repository by `./gradlew publish`.
 
+If you want to specify a subprojects, you can add `bomGroups` property. When generate
+Maven BOM of the project, only specific subprojects will be added into this bom file as dependency. 
+```groovy
+ext {
+    bomGroups = [
+            ':module1': [':module1:submodule1', ':module1:submodule2'],
+            ':module2': [':module2:submodule1', ':module2:submodule2']
+    ]
+}
+```
+
 ## Building shaded JARs with `shade` flag
 
 Let's say you have a project that depends on a very old version of Guava and

--- a/README.md
+++ b/README.md
@@ -485,7 +485,9 @@ generate Maven BOM based on the dependencies specified in `dependencies.yml`.
 Maven repository by `./gradlew publish`.
 
 If you want to specify a subprojects, you can add `bomGroups` property. When generate
-Maven BOM of the project, only specific subprojects will be added into this bom file as dependency. 
+Maven BOM of the project, The specific subprojects will be added into this bom file as dependency.
+If you exclude a project from the `bomGroups` property, the generated bom file of that project will
+have subprojects as if you didn't use the `bomGroups` property.
 ```groovy
 ext {
     bomGroups = [

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -27,15 +27,19 @@ configure(projectsWithFlags('bom')) {
                         throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
                     }
 
-                    for (Map.Entry<String, List<String>> e : bomGroups.entrySet()) {
-                        if (rootProject.project(e.key) == project) {
-                            if (!(e.value instanceof List)) {
-                                throw new IllegalStateException("bomGroup's value must be a List: ${e.value}")
-                            }
+                    if (!bomGroups.containsKey(':' + project.name)) {
+                        api "${p.group}:${p.ext.artifactId}:${p.version}"
+                    } else {
+                        for (Map.Entry<String, List<String>> e : bomGroups.entrySet()) {
+                            if (rootProject.project(e.key) == project) {
+                                if (!(e.value instanceof List)) {
+                                    throw new IllegalStateException("bomGroup's value must be a List: ${e.value}")
+                                }
 
-                            for (String sub : e.value) {
-                                if (rootProject.project(sub) == p) {
-                                    api "${p.group}:${p.ext.artifactId}:${p.version}"
+                                for (String sub : e.value) {
+                                    if (rootProject.project(sub) == p) {
+                                        api "${p.group}:${p.ext.artifactId}:${p.version}"
+                                    }
                                 }
                             }
                         }

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -38,6 +38,7 @@ configure(projectsWithFlags('bom')) {
                         for (String sub : subs) {
                             if (rootProject.project(sub) == p) {
                                 api "${p.group}:${p.ext.artifactId}:${p.version}"
+                                break
                             }
                         }
                     }

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -21,7 +21,28 @@ configure(projectsWithFlags('bom')) {
                 }
                 return "${a.ext.artifactId}".compareTo("${b.ext.artifactId}")
             }.each { p ->
-                api "${p.group}:${p.ext.artifactId}:${p.version}"
+                if (rootProject.ext.has('bomGroups')) {
+                    def bomGroups = rootProject.ext.bomGroups
+                    if (!(bomGroups instanceof Map)) {
+                        throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
+                    }
+
+                    for (Map.Entry<String, String> e : bomGroups.entrySet()) {
+                        if (rootProject.project(e.key) == project) {
+                            if (!(e.value instanceof List)) {
+                                throw new IllegalStateException("bomGroup's value is must be a List: ${e.value}")
+                            }
+
+                            for (String sub : e.value) {
+                                if (rootProject.project(sub) == p) {
+                                    api "${p.group}:${p.ext.artifactId}:${p.version}"
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    api "${p.group}:${p.ext.artifactId}:${p.version}"
+                }
             }
         }
     }

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -27,20 +27,17 @@ configure(projectsWithFlags('bom')) {
                         throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
                     }
 
-                    if (!bomGroups.containsKey(':' + project.name)) {
+                    def moduleName = ':' + project.name
+                    if (!bomGroups.containsKey(moduleName)) {
                         api "${p.group}:${p.ext.artifactId}:${p.version}"
                     } else {
-                        for (Map.Entry<String, List<String>> e : bomGroups.entrySet()) {
-                            if (rootProject.project(e.key) == project) {
-                                if (!(e.value instanceof List)) {
-                                    throw new IllegalStateException("bomGroup's value must be a List: ${e.value}")
-                                }
-
-                                for (String sub : e.value) {
-                                    if (rootProject.project(sub) == p) {
-                                        api "${p.group}:${p.ext.artifactId}:${p.version}"
-                                    }
-                                }
+                        def subs = bomGroups.get(moduleName)
+                        if (!(subs.value instanceof List)) {
+                            throw new IllegalStateException("bomGroup's value must be a List: ${subs.value}")
+                        }
+                        for (String sub : subs) {
+                            if (rootProject.project(sub) == p) {
+                                api "${p.group}:${p.ext.artifactId}:${p.version}"
                             }
                         }
                     }

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -14,14 +14,18 @@ configure(projectsWithFlags('bom')) {
 
     dependencies {
         constraints {
-            def bomGroups = rootProject.ext.bomGroups
-            def isNeededCheck = false;
-            if (!(bomGroups instanceof Map)) {
-                throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
-            }
-            if (!bomGroups.containsKey(project.path)) {
-                logger.warn(project.name + " won't be included to bomGroups property")
-                isNeededCheck = true;
+            boolean isNeededCheck = false
+            def bomGroups, subs
+            if (rootProject.ext.has('bomGroups')) {
+                bomGroups = rootProject.ext.bomGroups
+                if (!(bomGroups instanceof Map)) {
+                    throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
+                }
+                if (!bomGroups.containsKey(project.path)) {
+                    logger.warn(project.name + " won't be included to bomGroups property")
+                    isNeededCheck = true;
+                }
+                subs = bomGroups.get(project.path)
             }
 
             projectsWithFlags('java', 'publish').toList().sort { a, b ->
@@ -35,7 +39,6 @@ configure(projectsWithFlags('bom')) {
                     if (!bomGroups.containsKey(project.path)) {
                         api "${p.group}:${p.ext.artifactId}:${p.version}"
                     } else {
-                        def subs = bomGroups.get(project.path)
                         if (!(subs.value instanceof List)) {
                             throw new IllegalStateException("bomGroups' value must be a List: ${subs.value}")
                         }

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -26,6 +26,9 @@ configure(projectsWithFlags('bom')) {
                     isNeededCheck = true
                 }
                 subs = bomGroups.get(project.path)
+                if (!(subs.value instanceof List)) {
+                    throw new IllegalStateException("bomGroups' value must be a List: ${subs.value}")
+                }
             }
 
             projectsWithFlags('java', 'publish').toList().sort { a, b ->
@@ -39,10 +42,6 @@ configure(projectsWithFlags('bom')) {
                     if (!bomGroups.containsKey(project.path)) {
                         api "${p.group}:${p.ext.artifactId}:${p.version}"
                     } else {
-                        if (!(subs.value instanceof List)) {
-                            throw new IllegalStateException("bomGroups' value must be a List: ${subs.value}")
-                        }
-
                         if (subs.contains(p.path)) {
                             api "${p.group}:${p.ext.artifactId}:${p.version}"
                         } else if (p.path.startsWith(project.path)) {

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -14,6 +14,16 @@ configure(projectsWithFlags('bom')) {
 
     dependencies {
         constraints {
+            def bomGroups = rootProject.ext.bomGroups
+            def isNeededCheck = false;
+            if (!(bomGroups instanceof Map)) {
+                throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
+            }
+            if (!bomGroups.containsKey(project.path)) {
+                logger.warn(project.name + " won't be included to bomGroups property")
+                isNeededCheck = true;
+            }
+
             projectsWithFlags('java', 'publish').toList().sort { a, b ->
                 def groupComparison = "${a.group}".compareTo("${b.group}")
                 if (groupComparison != 0) {
@@ -22,11 +32,6 @@ configure(projectsWithFlags('bom')) {
                 return "${a.ext.artifactId}".compareTo("${b.ext.artifactId}")
             }.each { p ->
                 if (rootProject.ext.has('bomGroups')) {
-                    def bomGroups = rootProject.ext.bomGroups
-                    if (!(bomGroups instanceof Map)) {
-                        throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
-                    }
-
                     if (!bomGroups.containsKey(project.path)) {
                         api "${p.group}:${p.ext.artifactId}:${p.version}"
                     } else {
@@ -37,11 +42,18 @@ configure(projectsWithFlags('bom')) {
 
                         if (subs.contains(p.path)) {
                             api "${p.group}:${p.ext.artifactId}:${p.version}"
+                        } else if (p.path.startsWith(project.path)) {
+                            logger.warn(p.name + " won't be included in " + project.name + " bom")
+                            isNeededCheck = true;
                         }
                     }
                 } else {
                     api "${p.group}:${p.ext.artifactId}:${p.version}"
                 }
+            }
+
+            if (isNeededCheck) {
+                logger.warn("If not intended, Please check bomGroups property")
             }
         }
     }

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -27,19 +27,16 @@ configure(projectsWithFlags('bom')) {
                         throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
                     }
 
-                    def moduleName = ':' + project.name
-                    if (!bomGroups.containsKey(moduleName)) {
+                    if (!bomGroups.containsKey(project.path)) {
                         api "${p.group}:${p.ext.artifactId}:${p.version}"
                     } else {
-                        def subs = bomGroups.get(moduleName)
+                        def subs = bomGroups.get(project.path)
                         if (!(subs.value instanceof List)) {
                             throw new IllegalStateException("bomGroups' value must be a List: ${subs.value}")
                         }
-                        for (String sub : subs) {
-                            if (rootProject.project(sub) == p) {
-                                api "${p.group}:${p.ext.artifactId}:${p.version}"
-                                break
-                            }
+
+                        if (subs.contains(p.path)) {
+                            api "${p.group}:${p.ext.artifactId}:${p.version}"
                         }
                     }
                 } else {

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -30,7 +30,7 @@ configure(projectsWithFlags('bom')) {
                     for (Map.Entry<String, String> e : bomGroups.entrySet()) {
                         if (rootProject.project(e.key) == project) {
                             if (!(e.value instanceof List)) {
-                                throw new IllegalStateException("bomGroup's value is must be a List: ${e.value}")
+                                throw new IllegalStateException("bomGroup's value must be a List: ${e.value}")
                             }
 
                             for (String sub : e.value) {

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -14,7 +14,6 @@ configure(projectsWithFlags('bom')) {
 
     dependencies {
         constraints {
-            boolean isNeededCheck = false
             def bomGroups, subs
             if (rootProject.ext.has('bomGroups')) {
                 bomGroups = rootProject.ext.bomGroups
@@ -22,8 +21,7 @@ configure(projectsWithFlags('bom')) {
                     throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
                 }
                 if (!bomGroups.containsKey(project.path)) {
-                    logger.warn(project.name + " won't be included to bomGroups property")
-                    isNeededCheck = true
+                    logger.warn("{} won't be included to bomGroups property. If not intended, Please check bomGroups property", project.name)
                 }
                 subs = bomGroups.get(project.path)
                 if (!(subs.value instanceof List)) {
@@ -45,17 +43,12 @@ configure(projectsWithFlags('bom')) {
                         if (subs.contains(p.path)) {
                             api "${p.group}:${p.ext.artifactId}:${p.version}"
                         } else if (p.path.startsWith(project.path)) {
-                            logger.warn(p.name + " won't be included in " + project.name + " bom")
-                            isNeededCheck = true
+                            logger.warn("{} won't be included in {} bom. If not intended, Please check bomGroups property", p.name, project.name)
                         }
                     }
                 } else {
                     api "${p.group}:${p.ext.artifactId}:${p.version}"
                 }
-            }
-
-            if (isNeededCheck) {
-                logger.warn("If not intended, Please check bomGroups property")
             }
         }
     }

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -33,7 +33,7 @@ configure(projectsWithFlags('bom')) {
                     } else {
                         def subs = bomGroups.get(moduleName)
                         if (!(subs.value instanceof List)) {
-                            throw new IllegalStateException("bomGroup's value must be a List: ${subs.value}")
+                            throw new IllegalStateException("bomGroups' value must be a List: ${subs.value}")
                         }
                         for (String sub : subs) {
                             if (rootProject.project(sub) == p) {

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -23,7 +23,7 @@ configure(projectsWithFlags('bom')) {
                 }
                 if (!bomGroups.containsKey(project.path)) {
                     logger.warn(project.name + " won't be included to bomGroups property")
-                    isNeededCheck = true;
+                    isNeededCheck = true
                 }
                 subs = bomGroups.get(project.path)
             }
@@ -47,7 +47,7 @@ configure(projectsWithFlags('bom')) {
                             api "${p.group}:${p.ext.artifactId}:${p.version}"
                         } else if (p.path.startsWith(project.path)) {
                             logger.warn(p.name + " won't be included in " + project.name + " bom")
-                            isNeededCheck = true;
+                            isNeededCheck = true
                         }
                     }
                 } else {

--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -27,7 +27,7 @@ configure(projectsWithFlags('bom')) {
                         throw new IllegalStateException("bomGroups must be a Map: ${bomGroups}")
                     }
 
-                    for (Map.Entry<String, String> e : bomGroups.entrySet()) {
+                    for (Map.Entry<String, List<String>> e : bomGroups.entrySet()) {
                         if (rootProject.project(e.key) == project) {
                             if (!(e.value instanceof List)) {
                                 throw new IllegalStateException("bomGroup's value must be a List: ${e.value}")


### PR DESCRIPTION
bomGroups property is for specifying subprojects. it is used with `bom` flag.

// project tree
module1
|- submodule1
|- submodule2
module2
|- submodule1
|- submodule2

settings.gradle
```groovy
includeWithFlags ':module1', 'bom'
includeWithFlags ':module1:submodule1', 'java', 'publish'
includeWithFlags ':module1:submodule2', 'java', 'publish'

includeWithFlags ':module2', 'bom'
includeWithFlags ':module2:submodule1', 'java', 'publish'
includeWithFlags ':module2:submodule2', 'java', 'publish'
```

build.gradle
```groovy
ext {
    bomGroups = [
            ':module1': [':module1:submodule1', ':module1:submodule2'],
            ':module2': [':module2:submodule1', ':module2:submodule2']
    ]
}
```

When I create `module2 bom`, `module1's subprojects` will be added to the pom file as a dependency. If use `bomGroups` property, `module1's submodules` won't be added to the `module2's pom` file.