### PR TITLE
Use JDK8 Jar for protoc-gen-grpc-kotlin

### DIFF
--- a/lib/java-rpc-proto.gradle
+++ b/lib/java-rpc-proto.gradle
@@ -56,7 +56,7 @@ configure(projectsWithFlags('java')) {
                     }
                     if (project.ext.hasFlag('kotlin-grpc')) {
                         kotlinGrpc {
-                            artifact = "io.grpc:protoc-gen-grpc-kotlin:${managedVersions['io.grpc:protoc-gen-grpc-kotlin']}:jdk7@jar"
+                            artifact = "io.grpc:protoc-gen-grpc-kotlin:${managedVersions['io.grpc:protoc-gen-grpc-kotlin']}:jdk8@jar"
                         }
                     }
 


### PR DESCRIPTION
Because JDK7 Jar is not work with grpc-kotlin-stub 1.3.0