### PR TITLE
Use Nexus staing only when `io.github.gradle-nexus.publish-plugin` is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea
+gradle/
+.gradle

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ sensible defaults. By applying them, you can:
    publishUrlForSnapshot=https://oss.sonatype.org/content/repositories/snapshots/
    publishUsernameProperty=ossrhUsername
    publishPasswordProperty=ossrhPassword
+   publishSignatureRequired=true
    googleAnalyticsId=UA-XXXXXXXX
    javaSourceCompatibility=1.8
    javaTargetCompatibility=1.8
@@ -475,6 +476,18 @@ $ ./gradlew test -PbuildJdkVersion=15 -PtestJavaVersion=8
     myproject-foo.shortCommitHash=2efe73d5
     myproject-foo.version=0.0.1-SNAPSHOT
     ```
+
+- If [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin) is enabled in 
+ `<project_root>/build.gradle`, [staging function](https://help.sonatype.com/repomanager3/nexus-repository-administration/staging)
+  is used to publish the artifacts. It is great for publishing your open source to Sonatype, and then to Maven 
+  Central, in a fully automated fashion. 
+
+  ```groovy
+  // in build.gradle
+  plugins {
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+  }
+  ```
 
 ## Generating Maven BOM with `bom` flag
 

--- a/lib/common-publish.gradle
+++ b/lib/common-publish.gradle
@@ -49,13 +49,17 @@ subprojects {
     }
 }
 
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri(publishUrlForRelease - "staging/deploy/maven2/"))
-            snapshotRepositoryUrl.set(uri(publishUrlForSnapshot))
-            username = project.findProperty(publishUsernameProperty)
-            password =  project.findProperty(publishPasswordProperty)
+def publishToStaging = rootProject.plugins.findPlugin('io.github.gradle-nexus.publish-plugin') != null
+if (publishToStaging) {
+    apply plugin: "io.github.gradle-nexus.publish-plugin"
+    nexusPublishing {
+        repositories {
+            sonatype {
+                nexusUrl.set(uri(publishUrlForRelease - "staging/deploy/maven2/"))
+                snapshotRepositoryUrl.set(uri(publishUrlForSnapshot))
+                username = project.findProperty(publishUsernameProperty)
+                password = project.findProperty(publishPasswordProperty)
+            }
         }
     }
 }
@@ -71,6 +75,27 @@ configure(projectsWithFlags('publish')) {
                 useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
             }
             required { true }
+        }
+    }
+
+    if (!publishToStaging) {
+        publishing {
+            repositories {
+                maven {
+                    if (project.hasProperty('publishUrl')) {
+                        url project.findProperty('publishUrl')
+                    } else if (isReleaseVersion) {
+                        url publishUrlForRelease
+                    } else {
+                        url publishUrlForSnapshot
+                    }
+
+                    credentials {
+                        username = project.findProperty(publishUsernameProperty)
+                        password = project.findProperty(publishPasswordProperty)
+                    }
+                }
+            }
         }
     }
 

--- a/lib/prerequisite.gradle
+++ b/lib/prerequisite.gradle
@@ -1,12 +1,10 @@
 try {
     rootProject.apply plugin: 'com.google.osdetector'
-    rootProject.apply plugin: 'io.github.gradle-nexus.publish-plugin'
 } catch (UnknownPluginException e) {
     throw new IllegalStateException('''Add the following to the top-level build.gradle file:
 
 plugins {
     id 'com.google.osdetector' version '1.6.2' apply false
-    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
 }
 ''')
 }


### PR DESCRIPTION
Motivation:

[Staging](https://help.sonatype.com/repomanager3/nexus-repository-administration/staging)
is an optional feature to move components between repositories.
It is useful for OSS Sonatype. However, some companies may use legacy
Nexus or disable the feature somehow. It is only available in Nexus
Repository Pro.

Modifications:

- Use staging repository only when `io.github.gradle-nexus.publish-plugin`
  is explicitly enabled by users' build.gradle

Result:

- Fix the regression raised by #111