### PR TITLE
Fix a bug where `dependencyUpdates` task does not work correctly with `dependencies.toml`

### DIFF
--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -1,3 +1,5 @@
+import com.github.benmanes.gradle.versions.reporter.*
+import com.github.benmanes.gradle.versions.reporter.result.*
 import org.yaml.snakeyaml.Yaml
 
 buildscript {
@@ -8,7 +10,7 @@ buildscript {
 
     dependencies {
         // These should be the only dependencies that need hard-coded versions.
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.39.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.42.0'
         classpath 'org.yaml:snakeyaml:1.29'
     }
 }
@@ -30,7 +32,6 @@ def dependencyManagementProject = dependencyManagementProjects[0]
 
 configure(dependencyManagementProject) {
     apply plugin: 'java-platform'
-    apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
 
     repositories {
         google()
@@ -51,6 +52,10 @@ configure(dependencyManagementProject) {
             }
         }
     }
+}
+
+configure(rootProject) {
+    apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
 
     tasks {
         dependencyUpdates {
@@ -59,7 +64,8 @@ configure(dependencyManagementProject) {
             resolutionStrategy {
                 componentSelection { rules ->
                     rules.all { ComponentSelection selection ->
-                        boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview'].any { qualifier ->
+                        boolean rejected = ['alpha', 'beta', 'ea', 'rc',
+                                            'cr', 'm', 'preview'].any { qualifier ->
                             selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
                         }
                         if (rejected) {
@@ -70,19 +76,16 @@ configure(dependencyManagementProject) {
             }
 
             checkConstraints = true
-
-            // We have downgraded versions for legacy artifacts which versions plugin has no way of handling.
-            // But we can provide a reminder to manually check for updates.
-            doLast {
-                logger.quiet "Don't forget to check the following for updates to legacy version downgrades"
-                managedDependencyOverrides.each { override ->
-                    def (group, artifact, version) = override.split(':')
-                    def parts = version.split('\\.')
-                    if (parts.length >= 2) {
-                        logger.quiet "${artifact} is currently version ${version}"
-                        logger.quiet "https://search.maven.org/search?q=g:${group}%20a:${artifact}%20v:${parts[0]}.${parts[1]}.*\n"
-                    }
+            outputFormatter = result -> {
+                File filename = new File(outputDir, 'report.txt')
+                project.file(outputDir).mkdirs()
+                File outputFile = project.file(filename)
+                def reporter = new GentlePlainTextReporter(project, "release", "release-candidate")
+                reporter.write(System.out, result)
+                outputFile.withPrintWriter { PrintWriter pw ->
+                    reporter.write(pw, result)
                 }
+                logger.lifecycle '\nGenerated report file ' + filename
             }
         }
     }
@@ -231,4 +234,48 @@ static def getManagedVersions(Project rootProject) {
         }
     }
     return managedVersions
+}
+
+final class GentlePlainTextReporter implements Reporter {
+
+    private final Reporter delegate
+
+    GentlePlainTextReporter(Project project, String revision, String gradleReleaseChannel) {
+        delegate = new PlainTextReporter(project, revision, gradleReleaseChannel)
+    }
+
+    def write(Object printStream, Result result) {
+        delegate.write(printStream, updateProjectUrl(result))
+    }
+
+    private static Result updateProjectUrl(Result result) {
+        DependenciesGroup<DependencyOutdated> outdated = result.outdated
+        def updated = outdated.dependencies.collect { old ->
+            List versionParts = []
+            if (old.version != null) {
+                versionParts = old.version.split('\\.').toList()
+            }
+            if (versionParts.size() < 2) {
+                return old
+            }
+
+            String quickSearchLink = "https://search.maven.org/search?q=g:${old.group}%20a:${old.name}%20v:" +
+                                     "${versionParts[0]}.${versionParts[1]}.*\n"
+            String projectUrl
+            if (old.projectUrl == null) {
+                projectUrl = quickSearchLink
+            } else {
+                projectUrl = "${old.projectUrl}\n     $quickSearchLink"
+            }
+            return new DependencyOutdated(old.group, old.name, old.version, projectUrl, old.userReason, old.available)
+        } as SortedSet
+
+        DependenciesGroup<DependencyOutdated> outdatedWithNote = new DependenciesGroup<>(outdated.count, updated)
+        return new Result(result.count, result.current, outdatedWithNote, result.exceeded, result.undeclared,
+                          result.unresolved, result.gradle)
+    }
+
+    String getFileExtension() {
+        return delegate.getFileExtension()
+    }
 }


### PR DESCRIPTION
Motivation:

The `dependencyUpdates` task is configured in
`dependencyManagementProject` does not report new versions in Maven Central.
https://github.com/line/gradle-scripts/blob/5c55c9bc72fc22f46deaa14fa3955c6664757c9b/lib/common-dependencies.gradle#L56
I don't know the exact reason for that but `dependencyUpdates` task is worked correctly when it is configured in the root project guided in `gradle-versions-plugin` documentation.
https://github.com/ben-manes/gradle-versions-plugin#multi-project-build

Modifications:

- Upgrade gradle-versions-plugin to 0.42.0 from 0.39.0
- Move `dependencyUpdates` configuration to `rootProject`.
- Add a custom reporter so as to print Maven Search URLs with all new versions together.
  - It would be helpful to check legacy versions. `managedDependencyOverrides` is used to provide the URL but it no longer works with version catalog.

Result:

You can now correctly see new versions with `dependencyUpdates` task when using `dependencies.toml`

Note: this PR was reviewed in https://github.com/line/armeria/pull/4414