### PR TITLE
Make `managedVersions` backward compatible.

### DIFF
--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -152,38 +152,12 @@ configure(rootProject) {
             group: 'Build',
             description: 'Generates the file that contains dependency versions.') {
 
-        inputs.property("catalog", project.extensions.getByType(VersionCatalogsExtension))
         def f = file("${project.buildDir}/managed_versions.yml")
         outputs.file(f)
 
         doLast {
             f.parentFile.mkdir()
-            managedVersions = [:]
-            inputs.properties["catalog"].catalogNames.forEach { name ->
-                def catalog = catalogs.named(name)
-                versions = [:] withDefault { [] }
-                catalog.libraryAliases.forEach { alias ->
-                    def library = catalog.findLibrary(alias).get().get()
-                    versions["libraries"].add([alias: alias, module: library.toString])
-                }
-
-                catalog.pluginAliases.forEach { alias ->
-                    def plugin = catalog.findPlugin(alias).get().get()
-                    versions["plugins"].add([alias: alias, plugin: plugin.toString])
-                }
-
-                catalog.versionAliases.forEach { alias ->
-                    def version = catalog.findVersion(alias).get()
-                    versions["versions"].add([alias: alias, version: version])
-                }
-
-                catalog.bundleAliases.forEach { alias ->
-                    def bundle = catalog.findBundle(alias).get().get()
-                    versions["bundles"].add([alias: alias, bundle: bundle.toString])
-                }
-                managedVersions[name] = versions
-            }
-
+            def managedVersions = getManagedVersions(rootProject)
             f.withWriter('UTF-8') {
                 new Yaml().dump(managedVersions, it)
             }


### PR DESCRIPTION
Motivation:

Central Dogma uses `managed_versions.yml` to fill templated values in '*.rst` files
https://github.com/line/centraldogma/blob/e20860e5b6d3b9428c3cfec17f4581fff54a2dba/site/src/sphinx/conf.py#L27 I thought the file was only used to debug the current dependencies. So I changed the format without considering compatibility.

Modifications:

- Use `managedVersions` variable to create `managed_versions.yml`.

Result:

Fixed regression made when applying version catalog.