### PR TITLE
Fix `jvmTarget` & `ktlint` config in `kotlin` flag preset

### DIFF
--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -2,7 +2,7 @@ configure(projectsWithFlags('kotlin')) {
 
     apply plugin: 'kotlin'
 
-    def target = "1.8"
+    def target = project.findProperty('javaTargetCompatibility') ?: '1.8'
     def compilerArgs = ['-java-parameters', '-Xjsr305=strict', '-Xskip-prerelease-check']
     compileKotlin {
         kotlinOptions.jvmTarget = target
@@ -17,8 +17,6 @@ configure(projectsWithFlags('kotlin')) {
         apply plugin: "org.jlleitschuh.gradle.ktlint"
 
         ktlint {
-            // https://github.com/pinterest/ktlint/issues/764
-            version.set("0.36.0")
             verbose.set(true)
             reporters {
                 reporter "html"
@@ -27,7 +25,7 @@ configure(projectsWithFlags('kotlin')) {
             disabledRules = ["import-ordering"]
 
             filter {
-                exclude("**/gen-src/**")
+                exclude { it.file.path.contains("gen-src/") }
             }
         }
 

--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -17,8 +17,6 @@ configure(projectsWithFlags('kotlin')) {
         apply plugin: "org.jlleitschuh.gradle.ktlint"
 
         ktlint {
-            // https://github.com/pinterest/ktlint/issues/764
-            version.set("0.36.0")
             verbose.set(true)
             reporters {
                 reporter "html"

--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -17,6 +17,8 @@ configure(projectsWithFlags('kotlin')) {
         apply plugin: "org.jlleitschuh.gradle.ktlint"
 
         ktlint {
+            // https://github.com/pinterest/ktlint/issues/764
+            version.set("0.36.0")
             verbose.set(true)
             reporters {
                 reporter "html"


### PR DESCRIPTION
Motivation:
* #133 

Modifications:
* Use `javaTargetCompatibility` property value for kotlin compile JVM target.
* Use `org.jlleitschuh.gradle.ktlint` plugin's default `ktlint` version.
* Fix `ktlint` filter exclude condition for `gen-src` so that it can properly exclude dynamically attached sources.