### PR TITLE
Fix gRPC module build failure with duplicate source error

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ automatically:
 - `publish` - Makes a project publish its artifact to a Maven repository
 - `bom` - Makes a project publish Maven BOM based on `dependencies.toml`
 - `shade`, `relocate` and `trim` - Makes a Java project produce an additional 'shaded' JAR
-- `reactor-grpc` or `rxgrpc` - Enables [`reactor-grpc`](https://github.com/salesforce/reactive-grpc/tree/master/reactor) or [`rxgrpc`](https://github.com/salesforce/reactive-grpc/tree/master/rx-java) support to the project
+- `reactor-grpc`, `rxgrpc` or `kotlin-grpc` - Enables [`reactor-grpc`](https://github.com/salesforce/reactive-grpc/tree/master/reactor), [`rxgrpc`](https://github.com/salesforce/reactive-grpc/tree/master/rx-java) or [`kotlin-grpc`](https://github.com/grpc/grpc-kotlin) support to the project
 
 We will learn what these flags exactly do in the following sections.
 

--- a/lib/java-rpc-proto.gradle
+++ b/lib/java-rpc-proto.gradle
@@ -114,11 +114,6 @@ configure(projectsWithFlags('java')) {
             }
         }
 
-        // Add the generated 'grpc' directories to the source sets.
-        project.sourceSets.all { sourceSet ->
-            sourceSet.java.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/grpc")
-        }
-
         // Make sure protoc runs before the resources are copied so that .dsc files are included.
         project.afterEvaluate {
             project.sourceSets.each { sourceSet ->

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -56,13 +56,16 @@ configure(projectsWithFlags('java')) {
     afterEvaluate {
         // Add the generated source directories to the source sets.
         // This should run in 'afterEvaluate' so that protobuf plugin which also adds
-        // generated files to java source set applied first.
+        // generated files to source set applied first.
         project.sourceSets.all { sourceSet ->
             def javaSrcDir = file("${project.ext.genSrcDir}/${sourceSet.name}/java")
+            def resourceSrcDir = file("${project.ext.genSrcDir}/${sourceSet.name}/resources")
             if (!sourceSet.java.srcDirs.contains(javaSrcDir)) {
                 sourceSet.java.srcDir javaSrcDir
             }
-            sourceSet.resources.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/resources")
+            if (!sourceSet.resources.srcDirs.contains(resourceSrcDir)) {
+                sourceSet.resources.srcDir resourceSrcDir
+            }
         }
         Task generateSourcesTask = project.tasks.findByName('generateSources')
         if (generateSourcesTask != null) {

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -53,12 +53,17 @@ configure(projectsWithFlags('java')) {
         }
     }
 
-    // Add the generated source directories to the source sets.
-    project.sourceSets.all { sourceSet ->
-        sourceSet.java.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/java")
-        sourceSet.resources.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/resources")
-    }
     afterEvaluate {
+        // Add the generated source directories to the source sets.
+        // This should run in 'afterEvaluate' so that protobuf plugin which also adds
+        // generated files to java source set applied first.
+        project.sourceSets.all { sourceSet ->
+            def javaSrcDir = file("${project.ext.genSrcDir}/${sourceSet.name}/java")
+            if (!sourceSet.java.srcDirs.contains(javaSrcDir)) {
+                sourceSet.java.srcDir javaSrcDir
+            }
+            sourceSet.resources.srcDir file("${project.ext.genSrcDir}/${sourceSet.name}/resources")
+        }
         Task generateSourcesTask = project.tasks.findByName('generateSources')
         if (generateSourcesTask != null) {
             tasks.sourcesJar.dependsOn(generateSourcesTask)


### PR DESCRIPTION
Motivation:
* #132

Modifications:
* Do not add `gen-src/${sourceSet.name}/grpc` to java source set. This will be automatically handled by protobuf plugin.
* Do not add `gen-src/${sourceSet.name}/java` if it's already added by protobuf plugin.