### PR TITLE
Make Gradle 7.6 compatable

### DIFF
--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -321,8 +321,9 @@ private Configuration configureShadedTestRuntimeConfiguration(
                     // Skip the excluded dependencies.
                     return
                 }
-
-                project.dependencies.add(shadedTestRuntime.name, dep)
+                // Do not use `project.dependencies.add(name, dep)` that discards the classifier of
+                // a dependency. See https://github.com/gradle/gradle/issues/23096
+                project.configurations.getByName(shadedTestRuntime.name).dependencies.add(dep)
             }
         }
     }

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -1,4 +1,4 @@
-def buildJdkVersion = 17
+def buildJdkVersion = Integer.parseInt(JavaVersion.current().getMajorVersion())
 if (rootProject.hasProperty('buildJdkVersion')) {
     def jdkVersion = Integer.parseInt(rootProject.findProperty('buildJdkVersion'))
     if (buildJdkVersion != jdkVersion) {
@@ -6,6 +6,8 @@ if (rootProject.hasProperty('buildJdkVersion')) {
         logger.quiet("Overriding JDK for build with ${buildJdkVersion}")
     }
 }
+
+logger.info("Using JDK ${buildJdkVersion} to build ${project.name}")
 rootProject.ext.set("buildJdkVersion", buildJdkVersion)
 
 def testJavaVersion = buildJdkVersion
@@ -16,6 +18,8 @@ if (rootProject.hasProperty('testJavaVersion')) {
         logger.quiet("Overriding JRE for tests with ${testJavaVersion}")
     }
 }
+
+logger.info("Using JRE ${testJavaVersion} to test ${project.name}")
 rootProject.ext.set("testJavaVersion", testJavaVersion)
 
 // Enable checkstyle if the rule file exists.

--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -2,15 +2,21 @@ configure(projectsWithFlags('kotlin')) {
 
     apply plugin: 'kotlin'
 
-    def target = project.findProperty('javaTargetCompatibility') ?: '1.8'
-    def compilerArgs = ['-java-parameters', '-Xjsr305=strict', '-Xskip-prerelease-check']
-    compileKotlin {
-        kotlinOptions.jvmTarget = target
-        kotlinOptions.freeCompilerArgs = compilerArgs
-    }
-    compileTestKotlin {
-        kotlinOptions.jvmTarget = target
-        kotlinOptions.freeCompilerArgs = compilerArgs
+    // compileJmhKotlin is injected by 'jmh' plugin while a benchmark module is being initialized.
+    afterEvaluate {
+        def target = project.tasks.findByName('compileJava')?.targetCompatibility ?:
+                project.findProperty('javaTargetCompatibility') ?: '1.8'
+        def compilerArgs = ['-java-parameters', '-Xjsr305=strict', '-Xskip-prerelease-check']
+        // A workaround to find all Kotlin compilation tasks.
+        // The standard way, `tasks.withType(KotlinCompile)`, does not work here.
+        tasks.matching {
+            def name = it.name
+            // Expected task names: "compile<Name>Kotlin" or "kaptGenerateStubs<Name>Kotlin"
+            (name.startsWith("compile") || name.startsWith("kaptGenerateStubs")) && name.endsWith("Kotlin")
+        }.each { task ->
+            task.kotlinOptions.jvmTarget = target
+            task.kotlinOptions.freeCompilerArgs = compilerArgs
+        }
     }
 
     if (!rootProject.hasProperty('noLint')) {


### PR DESCRIPTION
- Kotlin does not support Java 19 as the target bytecode. As the default version follows the current Java version, a specific target is necessary for release.
- Add a workaround that handles a regression in dependency in Gradle 7.6 See https://github.com/gradle/gradle/issues/23096 for details.
The PR reviewed in https://github.com/line/armeria/pull/4466