### PR TITLE
Make `testJavaVersion` property set on per-project basis

### DIFF
--- a/lib/java-alpn.gradle
+++ b/lib/java-alpn.gradle
@@ -1,9 +1,9 @@
-// JDK 9 or above does not require Jetty ALPN agent at all.
-if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && rootProject.ext.testJavaVersion != 8) {
-    return
-}
-
 configure(projectsWithFlags('java')) {
+    // JDK 9 or above does not require Jetty ALPN agent at all.
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && project.ext.testJavaVersion != 8) {
+        return
+    }
+
     // Use Jetty ALPN agent if dependencyManagement mentions it.
     if (managedVersions.containsKey('org.mortbay.jetty.alpn:jetty-alpn-agent')) {
         configurations {

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -2,27 +2,15 @@ import java.util.regex.Pattern
 
 def buildJdkVersion = Integer.parseInt(JavaVersion.current().getMajorVersion())
 if (rootProject.hasProperty('buildJdkVersion')) {
-    def jdkVersion = Integer.parseInt(rootProject.findProperty('buildJdkVersion'))
+    def jdkVersion = Integer.parseInt(String.valueOf(rootProject.findProperty('buildJdkVersion')))
     if (buildJdkVersion != jdkVersion) {
         buildJdkVersion = jdkVersion
         logger.quiet("Overriding JDK for build with ${buildJdkVersion}")
     }
 }
 
-logger.info("Using JDK ${buildJdkVersion} to build ${project.name}")
+logger.info("Using JDK ${buildJdkVersion} for build")
 rootProject.ext.set("buildJdkVersion", buildJdkVersion)
-
-def testJavaVersion = buildJdkVersion
-if (rootProject.hasProperty('testJavaVersion')) {
-    def testVersion = Integer.parseInt(rootProject.findProperty('testJavaVersion'))
-    if (buildJdkVersion != testVersion) {
-        testJavaVersion = testVersion
-        logger.quiet("Overriding JRE for tests with ${testJavaVersion}")
-    }
-}
-
-logger.info("Using JRE ${testJavaVersion} to test ${project.name}")
-rootProject.ext.set("testJavaVersion", testJavaVersion)
 
 // Enable checkstyle if the rule file exists.
 def checkstyleConfigDir = "${rootProject.projectDir}/settings/checkstyle"
@@ -74,8 +62,20 @@ configure(projectsWithFlags('java')) {
     def targetJavaVersion = extractTargetJavaVersion(project)
     if (targetJavaVersion != null && targetJavaVersion < 8) {
         throw new IllegalArgumentException("The minimum target Java version ${version} specified " +
-                "for '${project.name}' cannot be smaller than 8")
+                "for '${project.path}' cannot be smaller than 8")
     }
+
+    def testJavaVersion = targetJavaVersion
+    if (project.hasProperty('testJavaVersion')) {
+        def testVersion = Integer.parseInt(String.valueOf(project.findProperty('testJavaVersion')))
+        if (testJavaVersion != testVersion) {
+            testJavaVersion = testVersion
+            logger.quiet("Overriding JRE for testing ${project.path} with ${testJavaVersion}")
+        }
+    }
+
+    logger.info("Using JRE ${testJavaVersion} to test ${project.path}")
+    project.ext.set("testJavaVersion", testJavaVersion)
 
     java {
         toolchain {
@@ -125,7 +125,7 @@ configure(projectsWithFlags('java')) {
         sourceCompatibility = targetJavaVersionStr ?: project.findProperty('javaSourceCompatibility') ?: '1.8'
         // the default targetJavaVersion is 'javaTargetCompatibility'
         targetCompatibility = targetJavaVersionStr ?: project.findProperty('javaTargetCompatibility') ?: '1.8'
-        if (buildJdkVersion >= 9) {
+        if (rootProject.ext.buildJdkVersion >= 9) {
             // Supported since java 9 https://openjdk.org/jeps/247
             options.release.set(Integer.valueOf(JavaVersion.toVersion(targetCompatibility).majorVersion))
         }
@@ -156,15 +156,15 @@ configure(projectsWithFlags('java')) {
         }
 
         // Use a different JRE for testing if necessary.
-        if (rootProject.ext.buildJdkVersion != rootProject.ext.testJavaVersion) {
+        if (rootProject.ext.buildJdkVersion != project.ext.testJavaVersion) {
             javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(rootProject.ext.testJavaVersion)
+                languageVersion = JavaLanguageVersion.of(project.ext.testJavaVersion)
             }
         }
 
         // disable tests for projects which target a higher java version
-        if (rootProject.ext.testJavaVersion < targetJavaVersion) {
-            project.logger.lifecycle("Skipping tests for ${project.name} since the " +
+        if (project.ext.testJavaVersion < targetJavaVersion) {
+            project.logger.lifecycle("Skipping tests for ${project.path} since the " +
                     "testJavaVersion(${testJavaVersion}) is smaller than the " +
                     "targetJavaVersion(${targetJavaVersion})")
             it.enabled = false


### PR DESCRIPTION
Motivation:

Each project can specify a different target Java version thanks to the `java<N>` flag which first appeared in e09c183118ed2c1f00aa84b180b58c26970887bf

However, because `testJavaVersion` is currently stored as a property of the root project, when two subprojects have two different `javaN` flag, the `testJavaVersion` set by the first subproject will be reused by the second subproject without respecting the `N` in the flag. For example, when `buildJdkVersion` is `8`, `:second` will never run its tests, because `testJavaVersion` is `8` for all projects:

```gradle
includeWithFlags ':first', 'java8'
includeWithFlags ':second', 'java17'
```

Modifications:

- Made `testJavaVersion` a per-project property, so that each project recalculates its `testJavaVersion`, i.t. `:first`'s `testJavaVersion` is `8` and `:second`'s is `17` unless a user specified explicitly.

Result:

- `testJavaVersion` is now calculated correctly when there are two subprojects with different target Java versions.