### PR TITLE
Fix `publish` task to work #4961

### DIFF
--- a/lib/java-rpc-proto.gradle
+++ b/lib/java-rpc-proto.gradle
@@ -130,6 +130,13 @@ configure(projectsWithFlags('java')) {
                     sourcesJarTask.dependsOn(task)
                 }
 
+                def kotlinSourcesJar = tasks.findByName('kotlinSourcesJar')
+                if (kotlinSourcesJar) {
+                    // A workaround for  ':grpc-kotlin:kotlinSourcesJar' uses this output of task
+                    // ':grpc-kotlin:generateProto' without declaring an explicit or implicit dependency.
+                    kotlinSourcesJar.dependsOn(task)
+                }
+
                 def copyAlpnAgentTask= tasks.findByName('copyAlpnAgent')
                 if (copyAlpnAgentTask) {
                     // A workaround for ':generateProto' uses this output of task ':copyAlpnAgent' without

--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -7,6 +7,7 @@ configure(projectsWithFlags('kotlin')) {
         def target = project.tasks.findByName('compileJava')?.targetCompatibility ?:
                 project.findProperty('javaTargetCompatibility') ?: '1.8'
         def compilerArgs = ['-java-parameters', '-Xjsr305=strict', '-Xskip-prerelease-check']
+        def copyAlpnAgentTask = tasks.findByName("copyAlpnAgent")
         // A workaround to find all Kotlin compilation tasks.
         // The standard way, `tasks.withType(KotlinCompile)`, does not work here.
         tasks.matching {
@@ -17,10 +18,14 @@ configure(projectsWithFlags('kotlin')) {
             task.kotlinOptions.jvmTarget = target
             task.kotlinOptions.freeCompilerArgs = compilerArgs
 
-            def copyAlpnAgentTask = tasks.findByName("copyAlpnAgent")
             if (copyAlpnAgentTask != null) {
                 task.dependsOn(copyAlpnAgentTask)
             }
+        }
+
+        def kotlinSourcesJar = tasks.findByName('kotlinSourcesJar')
+        if (kotlinSourcesJar != null && copyAlpnAgentTask != null) {
+            kotlinSourcesJar.dependsOn(copyAlpnAgentTask)
         }
     }
 

--- a/lib/scala.gradle
+++ b/lib/scala.gradle
@@ -63,7 +63,7 @@ configure(scala212 + scala213 + scala3) {
 
 configure(scala212) {
     dependencies {
-        implementation('org.scala-lang:scala-library:2.12.17')
+        implementation('org.scala-lang:scala-library:2.12.18')
         if (managedVersions.containsKey('org.scalameta:munit_2.12')) {
             testImplementation "org.scalameta:munit_2.12:${managedVersions['org.scalameta:munit_2.12']}"
         }
@@ -81,7 +81,7 @@ configure(scala212) {
 
 configure(scala213) {
     dependencies {
-        implementation 'org.scala-lang:scala-library:2.13.10'
+        implementation 'org.scala-lang:scala-library:2.13.11'
         if (managedVersions.containsKey('org.scalameta:munit_2.13')) {
             testImplementation "org.scalameta:munit_2.13:${managedVersions['org.scalameta:munit_2.13']}"
         }


### PR DESCRIPTION
Motivation:

`gradle publish` fails to publish because of illegal usage in Kotlin gRPC projects without dependencies.

```
Task ':grpc-kotlin:kotlinSourcesJar' uses this output of task
':grpc-kotlin:generateProto' without declaring an explicit or
implicit dependency. This can lead to incorrect results being produced,
depending on what order the tasks are executed.
```
https://github.com/line/armeria/actions/runs/5275219571/jobs/9540456642#step:8:1415

Modifications:

- Make `kotlinSourcesJar` depend on `generateProto` and `copyAlpnAgent`
- Miscellaneous) Update Scala versions

Result:

Publish artifacts to Maven Central