### PR TITLE
Fix a possible deadlock on the coverage task

### DIFF
--- a/lib/java-coverage.gradle
+++ b/lib/java-coverage.gradle
@@ -66,7 +66,6 @@ configure(rootProject) {
                 }
 
                 p.tasks.withType(Test).each { testTask ->
-                    reportTask.dependsOn(testTask.path)
                     reportTask.mustRunAfter(testTask)
                     testTask.finalizedBy(reportTask)
 


### PR DESCRIPTION
Motivation:

When `-Pcoverage` is specified, Gradle stopped after configuring tasks. After some debugging, I figured out that `reportTask.dependsOn(testTask.path)` prevented Gradle from executing tests.

Modifications:

- Removed `reportTask.dependsOn(testTask.path)` which looks redundant. JaCoCo task is working after tests without it.

Result:

No deadlock on the coverage task.