### PR TITLE
Avoid using `compileClasspath` to resolve POM dependencies

### DIFF
--- a/lib/java-publish.gradle
+++ b/lib/java-publish.gradle
@@ -8,10 +8,16 @@ configure(projectsWithFlags('publish', 'java')) {
                 suppressPomMetadataWarningsFor('optionalApiElements')
                 suppressPomMetadataWarningsFor('optionalRuntimeElements')
 
-                // Publish resolved versions
+                // Resolved versions are used to publish platform dependencies in pom XML.
                 versionMapping {
-                    allVariants {
+                    usage(Usage.JAVA_RUNTIME) {
                         fromResolutionResult()
+                    }
+                    usage(Usage.JAVA_API) {
+                        // compileOnly dependencies should not be included in the compile scope of POM. If we
+                        // don't exclude them, compileOnly dependencies are also used to resolve the final
+                        // dependency version.
+                        fromResolutionOf("runtimeClasspath")
                     }
                 }
 


### PR DESCRIPTION
The existing `versionMapping` strategy uses all variants to resolve the final dependency versions of POM. That makes `compileOnly` also taken into account although `compileOnly` should be ignored in POM.
Reference: https://github.com/line/armeria/pull/5118