### PR TITLE
Use buildJdkVersion for testJavaVersion when not specified

### DIFF
--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -90,7 +90,7 @@ configure(projectsWithFlags('java')) {
     targetJavaVersion = Integer.valueOf(JavaVersion.toVersion(javaTargetCompatibility).majorVersion)
     project.ext.set('targetJavaVersion', targetJavaVersion)
 
-    def testJavaVersion = targetJavaVersion
+    def testJavaVersion = buildJdkVersion
     if (project.hasProperty('testJavaVersion')) {
         def testVersion = Integer.parseInt(String.valueOf(project.findProperty('testJavaVersion')))
         if (testJavaVersion != testVersion) {


### PR DESCRIPTION
I believe that using the same version for build and testing is more natural when the properties are not specified. For example, if we run a Java project without this `gradle-scripts` using JDK19, the build and test are executed with JDK19.