### PR TITLE
Add Kotlin generated source directories to source sets

### DIFF
--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -17,6 +17,14 @@ configure(projectsWithFlags('kotlin')) {
             task.kotlinOptions.jvmTarget = target
             task.kotlinOptions.freeCompilerArgs = compilerArgs
         }
+
+        // Add the generated source directories to the source sets.
+        project.sourceSets.configureEach { sourceSet ->
+            def kotlinSrcDir = file("${project.ext.genSrcDir}/${sourceSet.name}/kotlin")
+            if (!sourceSet.java.srcDirs.contains(kotlinSrcDir)) {
+                sourceSet.java.srcDir kotlinSrcDir
+            }
+        }
     }
 
     if (!rootProject.hasProperty('noLint')) {

--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -21,8 +21,8 @@ configure(projectsWithFlags('kotlin')) {
         // Add the generated source directories to the source sets.
         project.sourceSets.configureEach { sourceSet ->
             def kotlinSrcDir = file("${project.ext.genSrcDir}/${sourceSet.name}/kotlin")
-            if (!sourceSet.java.srcDirs.contains(kotlinSrcDir)) {
-                sourceSet.java.srcDir kotlinSrcDir
+            if (!sourceSet.kotlin.srcDirs.contains(kotlinSrcDir)) {
+                sourceSet.kotlin.srcDir kotlinSrcDir
             }
         }
     }


### PR DESCRIPTION
`gen-src/main/java` is added to source sets but `gen-src/main/kotlin` is not added automatically.