### PR TITLE
Fix typo (depedencyManagement -> dependencyManagement)

### DIFF
--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -167,7 +167,7 @@ configure(projectsWithFlags('java')) {
     configurations.configureEach {
         ["Classpath", "AnnotationProcessor", "kapt"].each { name ->
             if (it.name.containsIgnoreCase(name)) {
-                it.extendsFrom(configurations.depedencyManagement)
+                it.extendsFrom(configurations.dependencyManagement)
             }
         }
     }

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -120,7 +120,7 @@ configure(relocatedProjects) {
                 if (!p.hasFlags('no_aggregation')) {
                     def configName = "proguardLibraryJars_${p.path.replace(':', '_')}"
                     def proguardLibraryJars = configurations.create(configName) {
-                        extendsFrom(p.configurations.depedencyManagement)
+                        extendsFrom(p.configurations.dependencyManagement)
                     }
 
                     proguardLibraryConfigs.add(proguardLibraryJars)
@@ -233,7 +233,7 @@ configure(relocatedProjects) {
         canBeResolved = true
         canBeConsumed = false
         extendsFrom(project.configurations.shadedJarTestImplementation)
-        extendsFrom(project.configurations.depedencyManagement)
+        extendsFrom(project.configurations.dependencyManagement)
     }
 
     // Update the classpath of the 'shadedTest' task after all shaded projects are evaluated


### PR DESCRIPTION
When synchronizing the changes in Armeria repo, I made a mistake in typing `dependencyManagement`