### PR TITLE
Increase retries for state transitions

### DIFF
--- a/lib/common-publish.gradle
+++ b/lib/common-publish.gradle
@@ -61,6 +61,11 @@ if (publishToStaging) {
                 password = project.findProperty(publishPasswordProperty)
             }
         }
+
+        transitionCheckOptions {
+            maxRetries.set(100)
+            delayBetween.set(Duration.ofSeconds(20))
+        }
     }
 }
 


### PR DESCRIPTION
The default retries and delay seems not enough when OSS Sonatype server is unstable.
https://github.com/gradle-nexus/publish-plugin#retries-for-state-transitions