### PR TITLE
Remove invalid access to List.value in bom.gradle

### DIFF
--- a/lib/bom.gradle
+++ b/lib/bom.gradle
@@ -26,8 +26,8 @@ configure(projectsWithFlags('bom')) {
                                     "Please check bomGroups property", project.name)
                     }
                     subs = bomGroups.get(project.path)
-                    if (!(subs.value instanceof List)) {
-                        throw new IllegalStateException("bomGroups' value must be a List: ${subs.value}")
+                    if (!(subs instanceof List)) {
+                        throw new IllegalStateException("bomGroups' value must be a List: ${subs}")
                     }
                 }
 


### PR DESCRIPTION
`subs` should be an ArrayList got from `bomGroups`, but this script somehow accesses to its property `subs.value`.

We confirmed with maintainers that this is a bug. This `subs.value` property happens to be a list before Java 17, but in Java 17 it becomes an invalid reference.

```
* What went wrong:
A problem occurred configuring project ':foo-project:bom'.
> Exception evaluating property 'value' for java.util.ArrayList, Reason: groovy.lang.MissingPropertyException: No such property: value for class: java.lang.String
```

So this PR gets rid of these references.