### PR TITLE
Replace commitDate format to ISO8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ $ ./gradlew test -PbuildJdkVersion=15 -PtestJavaVersion=8
     useful build information:
 
     ```
-    myproject-foo.commitDate=2018-01-23 19\:14\:12 +0900
+    myproject-foo.commitDate=2018-01-23T19:14:12+09:00
     myproject-foo.repoStatus=dirty
     myproject-foo.longCommitHash=2efe73d595a4687c9f8ad3d153ca8fe52604e20f
     myproject-foo.shortCommitHash=2efe73d5

--- a/lib/common-git.gradle
+++ b/lib/common-git.gradle
@@ -48,7 +48,7 @@ private def getRepoStatus() {
             version : project.version,
             longCommitHash : '0000000000000000000000000000000000000000',
             shortCommitHash : '0000000',
-            commitDate : '1970-01-01 00:00:00 +0000',
+            commitDate : '1970-01-01T00:00:00+00:00',
             repoStatus : 'unknown'
     ]
 
@@ -64,13 +64,13 @@ private def getRepoStatus() {
 
     // Retrieve the repository status from the Git repository.
     try {
-        def gitLogOut = project.ext.executeGit('log', '-1', '--format=format:%h%x20%H%x20%cd', '--date=iso', '--abbrev=9')
+        def gitLogOut = project.ext.executeGit('log', '-1', '--format=format:%h%x20%H%x20%cd', '--date=iso-strict', '--abbrev=9')
         if (gitLogOut) {
             logger.info("Latest commit: ${gitLogOut}")
             def tokens = gitLogOut.tokenize(' ')
             result.shortCommitHash = tokens[0]
             result.longCommitHash = tokens[1]
-            result.commitDate = tokens[2..4].join(' ')
+            result.commitDate = tokens[2]
         }
 
         def gitStatusOut = project.ext.executeGit('status', '--porcelain')


### PR DESCRIPTION
According to [git document](https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateltformatgt), git is using unique datetime format with `--iso` option.

Replacing it with strict ISO8601 format will improve usability.

