### PR TITLE
Prepare Gradle 9.0 deprecations

### DIFF
--- a/lib/java-publish.gradle
+++ b/lib/java-publish.gradle
@@ -16,7 +16,7 @@ configure(projectsWithFlags('publish', 'java')) {
                     jarOverrideFile = tasks.trimShadedJar.outJarFiles.find() as File
                     jarOverrideTask = tasks.trimShadedJar
                 } else if (tasks.findByName('shadedJar')) {
-                    jarOverrideFile = tasks.shadedJar.archivePath
+                    jarOverrideFile = tasks.shadedJar.archiveFile.get().asFile
                     jarOverrideTask = tasks.shadedJar
                 }
                 if (jarOverrideFile != null) {

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -46,7 +46,7 @@ configure(relocatedProjects) {
             description: 'Extracts the shaded main JAR.',
             dependsOn: tasks.shadedJar) {
 
-        from(zipTree(tasks.shadedJar.archivePath))
+        from(zipTree(tasks.shadedJar.archiveFile.get().asFile))
         from(sourceSets.main.output.classesDirs) {
             // Add the JAR resources excluded in the 'shadedJar' task.
             include '**/*.jar'
@@ -70,7 +70,7 @@ configure(relocatedProjects) {
             description: 'Extracts the shaded test JAR.',
             dependsOn: tasks.shadedTestJar) {
 
-        from(zipTree(tasks.shadedTestJar.archivePath))
+        from(zipTree(tasks.shadedTestJar.archiveFile.get().asFile))
         from(sourceSets.test.output.classesDirs) {
             // Add the JAR resources excluded in the 'shadedTestJar' task.
             include '**/*.jar'
@@ -96,7 +96,7 @@ configure(relocatedProjects) {
                 dependsOn it.tasks.shadedTestJar.path
             }
 
-            def shadedFile = tasks.shadedJar.archivePath
+            def shadedFile = tasks.shadedJar.archiveFile.get().asFile
             def shadedAndTrimmedFile = file(shadedFile.path.replaceFirst('-untrimmed-', '-shaded-'))
 
             injars shadedFile
@@ -107,11 +107,11 @@ configure(relocatedProjects) {
 
             // Include all other shaded JARs so that ProGuard does not trim the classes and methods
             // that are used actually.
-            injars tasks.shadedTestJar.archivePath
+            injars tasks.shadedTestJar.archiveFile.get().asFile
             relocatedProjects.each {
                 if (it != project && !it.hasFlags('no_aggregation')) {
-                    injars it.tasks.shadedJar.archivePath
-                    injars it.tasks.shadedTestJar.archivePath
+                    injars it.tasks.shadedJar.aarchiveFile.get().asFile
+                    injars it.tasks.shadedTestJar.archiveFile.get().asFile
                 }
             }
 
@@ -325,7 +325,7 @@ private Configuration configureShadedTestImplementConfiguration(
     if (recursedProject.tasks.findByName('trimShadedJar')) {
         project.dependencies.add(shadedJarTestImplementation.name, files(recursedProject.tasks.trimShadedJar.outJarFiles))
     } else if (recursedProject.tasks.findByName('shadedJar')) {
-        project.dependencies.add(shadedJarTestImplementation.name, files(recursedProject.tasks.shadedJar.archivePath))
+        project.dependencies.add(shadedJarTestImplementation.name, files(recursedProject.tasks.shadedJar.archiveFile.get().asFile))
     }
 
     def shadedDependencyNames = project.ext.relocations.collect { it['name'] }

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -49,7 +49,9 @@ configure(projectsWithFlags('java')) {
     apply plugin: 'idea'
     apply plugin: 'jvm-test-suite'
 
-    archivesBaseName = project.ext.artifactId
+    base {
+        archivesName = project.ext.artifactId
+    }
 
     // Delete the generated source directory on clean.
     ext {

--- a/settings-flags.gradle
+++ b/settings-flags.gradle
@@ -189,3 +189,4 @@ static void afterProjectsWithFlags(Project project, Iterable<?> flags, Closure<S
 // functionality.
 includeWithFlags ':dependencyManagement', 'dependencyManagement'
 project(':dependencyManagement').projectDir = file("${rootProject.projectDir}/build/dependencyManagement")
+project(':dependencyManagement').projectDir.mkdirs()

--- a/settings-flags.gradle
+++ b/settings-flags.gradle
@@ -187,6 +187,9 @@ static void afterProjectsWithFlags(Project project, Iterable<?> flags, Closure<S
 
 // We add a "virtual project", with no source code, to control dependency management using Gradle's platform
 // functionality.
+def virtualProjectsPath = "${rootDir}/build/virtual-projects"
 includeWithFlags ':dependencyManagement', 'dependencyManagement'
-project(':dependencyManagement').projectDir = file("${rootProject.projectDir}/build/dependencyManagement")
-project(':dependencyManagement').projectDir.mkdirs()
+project(":dependencyManagement").with {
+    projectDir = file("${virtualProjectsPath}/dependencyManagement")
+    projectDir.mkdirs()
+}


### PR DESCRIPTION
Motivation:

Prepare deprecations which will be removed or fail in Gradle 9.0

Modification:

- Create project directories under `build/virtual-projects`. Starting 9.0, Gradle will not run builds if a project directory is missing or read-only. (https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#deprecated_missing_project_directory)
- Deprecate base plugin convention with `base { }` (https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#base_convention_deprecation)
- Replace `AbstractArchiveTask.archivePath` with `archiveFile` (https://docs.gradle.org/8.7/javadoc/org/gradle/api/tasks/bundling/AbstractArchiveTask.html#getArchivePath--)

Result:

- Several deprecations of Gradle 9.0 are handled in advance