### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# https://help.github.com/articles/about-codeowners/
-
-* @jrhee17 @ikhoon @minwoox @trustin
-


### PR DESCRIPTION
Users usually clone this repository into their own repository using git subrepo. When cloning, the CODEOWNERS file is also cloned, which isn't necessary. We should remove the file until we pluginize this repository.