### PR TITLE
Include non-relocated modules when running `shadedTest`.

### DIFF
--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -69,7 +69,6 @@ configure(relocatedProjects) {
             group: 'Build',
             description: 'Extracts the shaded test JAR.',
             dependsOn: tasks.shadedTestJar) {
-
         from(zipTree(tasks.shadedTestJar.archiveFile.get().asFile))
         from(sourceSets.test.output.classesDirs) {
             // Add the JAR resources excluded in the 'shadedTestJar' task.
@@ -311,7 +310,8 @@ private void configureShadowTask(Project project, ShadowJar task, boolean isMain
 private Configuration configureShadedTestImplementConfiguration(
         Project project, Project recursedProject = project,
         Set<ExcludeRule> excludeRules = new HashSet<>(),
-        Set<Project> visitedProjects = new HashSet<>()) {
+        Set<Project> visitedProjects = new HashSet<>(),
+        boolean recursedProjectRelocated = true) {
 
     def shadedJarTestImplementation = project.configurations.getByName('shadedJarTestImplementation')
 
@@ -340,14 +340,24 @@ private Configuration configureShadedTestImplementConfiguration(
     }.each { cfg ->
         cfg.allDependencies.each { dep ->
             if (dep instanceof ProjectDependency) {
+                if (!dep.dependencyProject.hasFlag('java')) {
+                    // Do not add the dependencies of non-Java projects.
+                    return
+                }
                 // Project dependency - recurse later.
                 // Note that we recurse later to have immediate module dependencies higher precedence.
                 projectDependencies.add(dep)
             } else {
                 // Module dependency - add.
                 if (shadedDependencyNames.contains("${dep.group}:${dep.name}")) {
-                    // Skip the shaded dependencies.
-                    return
+                    if (recursedProjectRelocated) {
+                        // Skip the shaded dependencies.
+                        return
+                    }
+                    throw new IllegalStateException(
+                            "${recursedProject} has a shaded dependency: ${dep.group}:${dep.name} " +
+                                    "but it is not relocated. Please add a 'relocate' flag to " +
+                                    "${recursedProject} in settings.gradle.")
                 }
 
                 if (excludeRules.find { rule ->
@@ -365,9 +375,15 @@ private Configuration configureShadedTestImplementConfiguration(
 
     // Recurse into the project dependencies.
     projectDependencies.each { ProjectDependency dep ->
+        recursedProjectRelocated = true
+        if (!dep.dependencyProject.hasFlag('relocate')) {
+            project.configurations.getByName('shadedJarTestImplementation').dependencies.add(
+                    project.dependencies.project(path: dep.dependencyProject.path))
+            recursedProjectRelocated = false
+        }
         configureShadedTestImplementConfiguration(
                 project, dep.dependencyProject,
-                excludeRules + dep.excludeRules, visitedProjects)
+                excludeRules + dep.excludeRules, visitedProjects, recursedProjectRelocated)
     }
 
     return shadedJarTestImplementation


### PR DESCRIPTION
Motivation:
When a non-relocated module (Module A) is used by a relocated module (Module B), running `:B:shadedTest` results in a `NoClassDefError` because Module A is not included in Module B's `shadedJarTestImplementation` configuration.

Modifications:
- Included non-relocated modules (e.g., Module A) in the `shadedJarTestImplementation` configuration of relocated modules (e.g., Module B).
- Raised an exception if a non-relocated module needs to be relocated.

Result:
- Running `shadedTest` for relocated modules now includes necessary non-relocated modules.