### PR TITLE
Provide an option to enable unshaded tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,9 @@ relocations [ { from: "com.google.common", to: "com.doe.john.myproject.shaded.gu
               { from: "com.google.thirdparty.publicsuffix", to: "com.doe.john.myproject.shaded.publicsuffix" } ]
 ```
 
+Unshaded tests are disabled by default when a shading task is configured. If you want to run unshaded tests,
+you can specify `-PpreferShadedTests=false` option.
+
 ### Trimming a shaded JAR with `trim` flag
 
 If you shade many dependencies, your JAR will grow huge, even if you only use

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -254,8 +254,13 @@ configure(relocatedProjects) {
 
     gradle.taskGraph.whenReady {
         // Skip unshaded tests if shaded tests will run.
+        // To enable, set the property 'preferShadedTests' to 'false'.
+        boolean runUnshadedTests = false
+        if (rootProject.hasProperty('preferShadedTests') && "false" == rootProject.property('preferShadedTests')) {
+            runUnshadedTests = true
+        }
         if (gradle.taskGraph.hasTask(tasks.shadedTest)) {
-            tasks.test.onlyIf { false }
+            tasks.test.onlyIf { runUnshadedTests }
         }
     }
 }


### PR DESCRIPTION
Motivation:

Unshaded tests are disabled by default when a shading task is configured. However, sometimes we want to run unshaded tests to check a bug in shaded tests.
See: https://github.com/line/armeria/pull/5789

Modifications:

- Add `-PpreferShadedTests=<boolean>` option to decide whether to use shaded tests only or both run unshaded tests and shaded tests.

Result:

You can now specify `-PpreferShadedTests=false` option to unshaded tests.