### PR TITLE
Introduce shadow exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,10 @@ relocations [ { from: "com.google.common", to: "com.doe.john.myproject.shaded.gu
 Unshaded tests are disabled by default when a shading task is configured. If you want to run unshaded tests,
 you can specify `-PpreferShadedTests=false` option.
 
+
+If you would like to remove specific files when shading the JAR, you may specify the
+`-PshadowExclusions=<comma delimited files>` option.
+
 ### Trimming a shaded JAR with `trim` flag
 
 If you shade many dependencies, your JAR will grow huge, even if you only use

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -38,6 +38,14 @@ configure(relocatedProjects) {
         // Exclude the module metadata that'll become invalid after relocation.
         exclude '**/module-info.class'
 
+        def shadowExclusions = []
+        if (rootProject.hasProperty('shadowExclusions')) {
+            shadowExclusions = rootProject.findProperty('shadowExclusions').split(",")
+        }
+        shadowExclusions.each {
+            exclude it
+        }
+
         // Set the 'Automatic-Module-Name' property in MANIFEST.MF.
         if (project.ext.automaticModuleName != null) {
             manifest {


### PR DESCRIPTION
**Motivation**

We found that shaded SPI definitions may interfere with Java 9 modules. This PR introduces a `shadowExclusions` property which may be used to filter out pre-defined files.

See the following PR for more information: https://github.com/line/armeria/pull/5825