### PR TITLE
Introduce `failOnVersionConflict` per project/dep

### DIFF
--- a/lib/common-dependencies.gradle
+++ b/lib/common-dependencies.gradle
@@ -21,6 +21,7 @@ allprojects { p ->
         managedVersions = getManagedVersions(p.rootProject)
         findLibrary = this.&findLibrary.curry(p.rootProject)
         findPlugin = this.&findPlugin.curry(p.rootProject)
+        failOnVersionConflict = this.&failOnVersionConflict.curry(p)
     }
 }
 
@@ -329,5 +330,38 @@ final class GentlePlainTextReporter implements Reporter {
 
     String getFileExtension() {
         return delegate.getFileExtension()
+    }
+}
+
+/**
+ * A custom version of failOnVersionConflict which can limit which dependencies should be checked for conflict.
+ * Heavily inspired by https://github.com/gradle/gradle/issues/8813.
+ */
+static def failOnVersionConflict(Project project, ProviderConvertible<MinimalExternalModuleDependency> providerConvertible) {
+    return failOnVersionConflict(project, providerConvertible.asProvider())
+}
+
+static def failOnVersionConflict(Project project, Provider<MinimalExternalModuleDependency> dependencyProvider) {
+    if (!dependencyProvider.isPresent()) {
+        return
+    }
+    def targetDependency = dependencyProvider.get()
+    project.configurations.configureEach { config ->
+        incoming.afterResolve {
+            resolutionResult.allComponents {ResolvedComponentResult result ->
+                if (selectionReason.conflictResolution && moduleVersion != null) {
+                    // we don't care if the selected version is the one specified in dependencies.toml
+                    if (targetDependency.module == moduleVersion.module && targetDependency.version != moduleVersion.version) {
+                        def msg = "Project '${project.name}:${config.name}' resolution failed " +
+                                "for '${targetDependency.module}' with '${getSelectionReason()}"
+                        if (project.rootProject.hasProperty('debugDeps')) {
+                            project.logger.lifecycle(msg)
+                        } else {
+                            throw new IllegalStateException(msg)
+                        }
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
**Motivation**

Recently, a new armeria artifact was published with an unintended dependency bump up exposed in the resulting pom. (https://github.com/line/armeria/pull/5992)
To avoid this, I propose that `failOnVersionConflict` utility is used to detect if the resolved dependency.

Because introducing `failOnVersionConflict` for all projects and dependencies makes adoption difficult due to the many conflicts, this variant can narrow the scope on detecting version conflicts. Additionally, if there is a dependency conflict but the finally resolved version is the intended version an exception isn't raised.

**Modification**

- Introduced a new `failOnVersionConflict` which detects version conflicts per dependency.