### PR TITLE
Do not overwrite user-defined kotlin compiler args

### DIFF
--- a/lib/kotlin.gradle
+++ b/lib/kotlin.gradle
@@ -18,7 +18,7 @@ configure(projectsWithFlags('kotlin')) {
             (name.startsWith("compile") || name.startsWith("kaptGenerateStubs")) && name.endsWith("Kotlin")
         }.each { task ->
             task.kotlinOptions.jvmTarget = target
-            task.kotlinOptions.freeCompilerArgs = compilerArgs
+            task.kotlinOptions.freeCompilerArgs += compilerArgs
             if (kotlinTargetVersion != null) {
                 task.kotlinOptions.languageVersion = kotlinTargetVersion
                 task.kotlinOptions.apiVersion = kotlinTargetVersion


### PR DESCRIPTION
Motivation:

After https://github.com/line/gradle-scripts/pull/139, Kotlin's `freeCompilerArgs` is set in `afterEvaluate` block, which effectively overwrite any user-defined Kotlin `freeCompilerArgs` as the configuration is performed after any user defined 
configuration is evaluated.

This can be critical in some use cases where an app's feature depends on Kotlin's compiler argument (e.g. Hibernate validation on type parameter only works with `-Xemit-jvm-type-annotations` compiler argument).

Modification:

Used `plusAssign(+=)` operator to add gradle-scripts default kotlin compiler option upon user defined ones.