### PR TITLE
Support individual automatic module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,8 +696,16 @@ and artifact ID. For example:
 
 If enabled, each project with `java` flag will have the `automaticModuleName` property.
 
-You can override the automatic module name of a certain project via the `automaticModuleNameOverrides`
-extension property:
+You can override the automatic module name of a certain project via `automaticModuleNameOverride`:
+
+    ```groovy
+    ext {
+        // Change the automatic module name of a project to 'com.example.fubar'.
+        automaticModuleNameOverride = 'com.example.fubar'
+    }
+    ```
+
+Alternatively, you can also specify a mapping via the `automaticModuleNameOverrides` extension property:
 
     ```groovy
     ext {

--- a/lib/common-info.gradle
+++ b/lib/common-info.gradle
@@ -73,20 +73,35 @@ allprojects {
                 return null
             }
 
-            // Use the overridden one if available.
-            def overriddenAutomaticModuleName = findOverridden('automaticModuleNameOverrides', project)
-            if (overriddenAutomaticModuleName != null) {
-                return overriddenAutomaticModuleName
-            }
+            return project.provider {
+                // per-project override
+                if (project.ext.has('automaticModuleNameOverride')) {
+                    def override = project.ext.get('automaticModuleNameOverride')
+                    if (!(override instanceof String)) {
+                        throw new IllegalStateException("project.ext.automaticModuleNameOverride must be a String: ${override}")
+                    }
+                    return override
+                }
 
-            // Generate from the groupId and artifactId otherwise.
-            def groupIdComponents = String.valueOf(rootProject.group).split("\\.").toList()
-            def artifactIdComponents =
-                    String.valueOf(project.ext.artifactId).replace('-', '.').split("\\.").toList()
-            if (groupIdComponents.last() == artifactIdComponents.first()) {
-                return String.join('.', groupIdComponents + artifactIdComponents.drop(1))
-            } else {
-                return String.join('.', groupIdComponents + artifactIdComponents)
+                // Use the overridden one if available.
+
+                def overriddenAutomaticModuleName = findOverridden('automaticModuleNameOverrides', project)
+                if (overriddenAutomaticModuleName != null) {
+                    return overriddenAutomaticModuleName
+                }
+
+                // Generate from the groupId and artifactId otherwise.
+                def groupIdComponents = String.valueOf(rootProject.group).split("\\.").toList()
+                def artifactIdComponents =
+                        String.valueOf(project.ext.artifactId).replace('-', '.').split("\\.").toList()
+                def generatedName
+                if (groupIdComponents.last() == artifactIdComponents.first()) {
+                    generatedName = String.join('.', groupIdComponents + artifactIdComponents.drop(1))
+                } else {
+                    generatedName = String.join('.', groupIdComponents + artifactIdComponents)
+                }
+                generatedName = generatedName.replaceAll("\\.(\\d)", "_\$1")
+                return generatedName
             }
         }.call()
     }

--- a/lib/java-shade.gradle
+++ b/lib/java-shade.gradle
@@ -48,8 +48,10 @@ configure(relocatedProjects) {
 
         // Set the 'Automatic-Module-Name' property in MANIFEST.MF.
         if (project.ext.automaticModuleName != null) {
-            manifest {
-                attributes('Automatic-Module-Name': project.ext.automaticModuleName)
+            doFirst {
+                manifest {
+                    attributes('Automatic-Module-Name': project.ext.automaticModuleName.get())
+                }
             }
         }
     }

--- a/lib/java.gradle
+++ b/lib/java.gradle
@@ -166,8 +166,10 @@ configure(projectsWithFlags('java')) {
     // Set the 'Automatic-Module-Name' property in 'MANIFEST.MF' if `automaticModuleName` is not null.
     if (project.ext.automaticModuleName != null) {
         tasks.named('jar') {
-            manifest {
-                attributes('Automatic-Module-Name': project.ext.automaticModuleName)
+            doFirst {
+                manifest {
+                    attributes('Automatic-Module-Name': project.ext.automaticModuleName.get())
+                }
             }
         }
     }


### PR DESCRIPTION
The motivation for this change is better explained in the following PR: https://github.com/line/armeria/pull/6076

This changeset attempts to:
- Introduce `automaticModuleNameOverride` which overrides the module name for an individual project
- Avoid potential naming violations in java module names by replacing `\.[0-9]` to `_[0-9]`