### PR TITLE
Make `downloadListFile` public for Gradle 9 compatibility

### DIFF
--- a/lib/java-javadoc.gradle
+++ b/lib/java-javadoc.gradle
@@ -457,7 +457,7 @@ class DownloadJavadocPackageListTask extends DefaultTask {
         return [success, javadocUrl, listFileDir.asFile]
     }
 
-    private def downloadListFile(File listFile, URL listUrl) {
+    def downloadListFile(File listFile, URL listUrl) {
         // Do not attempt to download more than once.
         if (!visitedUrls.add(listUrl.toString())) {
             return


### PR DESCRIPTION
### Summary

In Gradle 9 (Groovy 4), as you know, closures can no longer access private members of a class when the runtime instance is a subclass — which is always the case for decorated task types such as`DownloadJavadocPackageListTask`. Calling a private method from a closure in such a class fails with:

> Could not find method downloadListFile() for arguments [...] on task ':...' of type DownloadJavadocPackageListTask

See: [Gradle 9 upgrade guide — Private properties and methods may be inaccessible in closures](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#private_properties_and_methods_may_be_inaccessible_in_closures)

`downloadListFile` is currently only called from plain method bodies(`addOfflineLink`), so nothing is broken today — this is a defensive change so that a future call from a closure does not fail at runtime.

#### How to re-produce the problem:

Please see: 
- https://github.com/otheng03/gradle-scripts/blob/738ea7361a332729109ee79618c612198a58a22c/tests/gradle9-private-members/case-a-task-class/build.gradle#L24-L36
- https://github.com/otheng03/gradle-scripts/blob/test-downloadListFile/tests/gradle9-private-members/README.md